### PR TITLE
BRT-65: rechazar imágenes corruptas en la subida

### DIFF
--- a/app/api/admin/upload/route.ts
+++ b/app/api/admin/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/auth";
 import { put } from "@vercel/blob";
+import sharp from "sharp";
 
 export async function POST(req: NextRequest) {
   const session = await requireAdmin(req);
@@ -16,13 +17,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Formato no permitido. Usá JPG, PNG o WEBP." }, { status: 400 });
   }
 
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  try {
+    // Fuerza la decodificación completa de los píxeles para detectar archivos dañados,
+    // ya que leer solo los metadatos no alcanza a detectar un JPEG truncado o corrupto.
+    await sharp(buffer).stats();
+  } catch {
+    return NextResponse.json({ error: "El archivo está dañado o no es una imagen válida." }, { status: 400 });
+  }
+
   const ext = file.name.split(".").pop()?.toLowerCase() ?? "jpg";
   const filename = `products/product-${Date.now()}.${ext}`;
 
   try {
-    const blob = await put(filename, file, { access: "public" });
+    const blob = await put(filename, buffer, { access: "public", contentType: file.type });
     return NextResponse.json({ url: blob.url });
-  } catch {
+  } catch (err) {
+    console.error("Error subiendo a Vercel Blob", err);
     return NextResponse.json({ error: "No se pudo subir la imagen. Probá de nuevo." }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- `app/api/admin/upload/route.ts` sólo validaba el `Content-Type` declarado por el navegador, no el contenido real del archivo.
- Un `.jpg` corrupto (bytes truncados/dañados) con MIME `image/jpeg` pasaba esa validación, Vercel Blob lo guardaba igual, y el frontend mostraba el toast de éxito — recién al renderizarlo con `next/image` fallaba la decodificación (400 "isn't a valid image"), dejando la imagen anterior pisada por una rota.
- Ahora se fuerza la decodificación completa con `sharp` (`sharp(buffer).stats()`) antes de subir a Blob; si falla, se devuelve 400 con un mensaje claro y el frontend (ya con el fix de BRT-64) revierte el preview y muestra el toast de error.

**Base:** esta PR apunta a `BRT-64-mensajes-error-imagenes` (no a `main`) porque depende del sistema de toasts agregado ahí. Una vez mergeada BRT-64, actualizo el base a `main` o se mergea en cadena.

## Test plan
Probado manualmente contra el server local con curl (sesión admin real):
- [x] Subir un JPEG truncado/corrupto → 400 `{"error":"El archivo está dañado o no es una imagen válida."}`
- [x] Subir un JPEG válido → 200 con URL de blob, sin cambios de comportamiento
- [ ] Validar en el navegador que se ve el toast de error y la imagen anterior se mantiene (pendiente de tu validación manual)

Jira: https://brot74.atlassian.net/browse/BRT-65

🤖 Generated with [Claude Code](https://claude.com/claude-code)