### PR TITLE
BRT-5: pipeline de optimización de imágenes al subir

### DIFF
--- a/app/api/admin/upload/route.ts
+++ b/app/api/admin/upload/route.ts
@@ -3,6 +3,26 @@ import { requireAdmin } from "@/lib/auth";
 import { put } from "@vercel/blob";
 import sharp from "sharp";
 
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const HEIC_EXTENSIONS = ["heic", "heif"];
+const MAX_ORIGINAL_BYTES = 5 * 1024 * 1024; // 5MB
+const MAX_WIDTH = 1200;
+const TARGET_BYTES = 150 * 1024; // 150KB, con margen bajo el límite de 200KB del ticket
+const QUALITY_STEPS = [75, 65, 55, 45, 35];
+
+async function optimizeImage(buffer: Buffer): Promise<Buffer> {
+  const pipeline = sharp(buffer)
+    .rotate() // respeta la orientación EXIF de fotos sacadas con el celular
+    .resize({ width: MAX_WIDTH, withoutEnlargement: true });
+
+  let result: Buffer | null = null;
+  for (const quality of QUALITY_STEPS) {
+    result = await pipeline.clone().webp({ quality }).toBuffer();
+    if (result.byteLength <= TARGET_BYTES) return result;
+  }
+  return result!;
+}
+
 export async function POST(req: NextRequest) {
   const session = await requireAdmin(req);
   if (!session) return NextResponse.json({ error: "No autorizado" }, { status: 401 });
@@ -12,26 +32,39 @@ export async function POST(req: NextRequest) {
 
   if (!file) return NextResponse.json({ error: "No se recibió archivo" }, { status: 400 });
 
-  const allowedTypes = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-  if (!allowedTypes.includes(file.type)) {
+  const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+  if (HEIC_EXTENSIONS.includes(ext) || ["image/heic", "image/heif"].includes(file.type)) {
+    return NextResponse.json(
+      { error: "Formato HEIC/HEIF no soportado. Convertí la foto a JPG, PNG o WEBP antes de subirla." },
+      { status: 400 }
+    );
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
     return NextResponse.json({ error: "Formato no permitido. Usá JPG, PNG o WEBP." }, { status: 400 });
+  }
+
+  if (file.size > MAX_ORIGINAL_BYTES) {
+    return NextResponse.json(
+      { error: `El archivo pesa demasiado. El límite es ${MAX_ORIGINAL_BYTES / (1024 * 1024)}MB.` },
+      { status: 400 }
+    );
   }
 
   const buffer = Buffer.from(await file.arrayBuffer());
 
+  let optimized: Buffer;
   try {
-    // Fuerza la decodificación completa de los píxeles para detectar archivos dañados,
-    // ya que leer solo los metadatos no alcanza a detectar un JPEG truncado o corrupto.
-    await sharp(buffer).stats();
-  } catch {
+    optimized = await optimizeImage(buffer);
+  } catch (err) {
+    console.error("Error optimizando imagen", err);
     return NextResponse.json({ error: "El archivo está dañado o no es una imagen válida." }, { status: 400 });
   }
 
-  const ext = file.name.split(".").pop()?.toLowerCase() ?? "jpg";
-  const filename = `products/product-${Date.now()}.${ext}`;
+  const filename = `products/product-${Date.now()}.webp`;
 
   try {
-    const blob = await put(filename, buffer, { access: "public", contentType: file.type });
+    const blob = await put(filename, optimized, { access: "public", contentType: "image/webp" });
     return NextResponse.json({ url: blob.url });
   } catch (err) {
     console.error("Error subiendo a Vercel Blob", err);


### PR DESCRIPTION
## Summary
- Al subir una imagen (producto o fecha) desde el admin, el backend ahora redimensiona a máx. 1200px de ancho, convierte a WebP y comprime de forma adaptativa (calidad 75→35 escalonada) hasta entrar cómodo bajo el límite de 200KB del ticket.
- Rechaza explícitamente HEIC/HEIF con un mensaje claro (decisión tomada en BRT-5: no se soporta, no se convierte).
- Valida que el original no supere 5MB, devolviendo un error claro si lo hace.
- La detección de archivos corruptos (BRT-65) queda integrada en el mismo pipeline de resize+encode, sin decodificar la imagen dos veces.

Implementa https://brot74.atlassian.net/browse/BRT-5. Depende de BRT-63 (spike) y BRT-64 (toasts de error/éxito), ambas ya mergeadas a main.

## Test plan
Verificado manualmente contra el endpoint real (Vercel Blob) con archivos generados on the fly:
- [x] Foto realista 3024×4032 (JPEG) → 200 OK, resultado WebP 1200×1600, ~9KB
- [x] Mismo contenido en PNG → 200 OK, convertido a WebP
- [x] Archivo >5MB → 400, error de tamaño
- [x] Archivo `.heic` → 400, error específico de formato no soportado
- [x] Archivo corrupto (bytes random con extensión `.jpg`) → 400, error de archivo dañado
- [x] Archivo `.txt` → 400, error de formato no permitido
- [ ] Verificación manual en el admin real (producto y fecha) — pendiente, la hace el reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)