### PR TITLE
chore: integration tests para admin (Prioridad 2)

### DIFF
--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,0 +1,6 @@
+import { signToken } from "@/lib/auth";
+
+export async function adminCookieHeader(): Promise<{ cookie: string }> {
+  const token = await signToken({ admin: true });
+  return { cookie: `admin_token=${token}` };
+}

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -63,3 +63,22 @@ export async function createCartReservation(
     },
   });
 }
+
+export async function createOrder(
+  deliverySlotId: number,
+  items: { productId: number; quantity: number; unitPrice: number }[] = [],
+  overrides: Partial<Prisma.OrderUncheckedCreateInput> = {}
+) {
+  return prisma.order.create({
+    data: {
+      customerName: "Cliente Test",
+      customerPhone: "1122334455",
+      deliverySlotId,
+      total: items.reduce((sum, i) => sum + i.unitPrice * i.quantity, 0),
+      status: "pending",
+      items: { create: items },
+      ...overrides,
+    },
+    include: { items: true },
+  });
+}

--- a/tests/integration/admin-orders.test.ts
+++ b/tests/integration/admin-orders.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/admin/orders/route";
+import { PATCH } from "@/app/api/admin/orders/[id]/route";
+import { prisma } from "@/lib/db";
+import { createProduct, createDeliverySlot, createProductStock, createOrder } from "../helpers/factories";
+import { adminCookieHeader } from "../helpers/auth";
+
+function getRequest(query = "") {
+  return new NextRequest(`http://localhost/api/admin/orders${query}`);
+}
+
+async function authedGetRequest(query = "") {
+  return new NextRequest(`http://localhost/api/admin/orders${query}`, { headers: await adminCookieHeader() });
+}
+
+function patchRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/orders/1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+describe("GET /api/admin/orders", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve los pedidos con datos del slot y los items", async () => {
+    const product = await createProduct({ name: "Campo" });
+    const slot = await createDeliverySlot({ dayLabel: "Lunes" });
+    await createOrder(slot.id, [{ productId: product.id, quantity: 2, unitPrice: 1000 }]);
+
+    const res = await GET(await authedGetRequest());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toHaveLength(1);
+    expect(json[0].slotLabel).toBe("Lunes");
+    expect(json[0].items[0]).toMatchObject({ name: "Campo", quantity: 2, unitPrice: 1000 });
+  });
+
+  it("filtra por slotId", async () => {
+    const product = await createProduct();
+    const slotA = await createDeliverySlot();
+    const slotB = await createDeliverySlot();
+    await createOrder(slotA.id, [{ productId: product.id, quantity: 1, unitPrice: 1000 }]);
+    await createOrder(slotB.id, [{ productId: product.id, quantity: 1, unitPrice: 1000 }]);
+
+    const res = await GET(await authedGetRequest(`?slotId=${slotA.id}`));
+    const json = await res.json();
+
+    expect(json).toHaveLength(1);
+  });
+});
+
+describe("PATCH /api/admin/orders/[id]", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await PATCH(patchRequest({ status: "paid" }), { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve 400 para un estado inválido", async () => {
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "no-existe" }, headers), { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("actualiza el estado del pedido", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 1, unitPrice: 1000 }]);
+
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "paid" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
+
+    expect(res.status).toBe(200);
+    const updated = await prisma.order.findUnique({ where: { id: order.id } });
+    expect(updated?.status).toBe("paid");
+  });
+
+  it("libera el stock reservado al cancelar el pedido", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 3 });
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }]);
+
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
+
+    expect(res.status).toBe(200);
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    expect(stock?.reservedStock).toBe(0);
+  });
+});

--- a/tests/integration/admin-slots-generate.test.ts
+++ b/tests/integration/admin-slots-generate.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/admin/slots/generate/route";
+import { prisma } from "@/lib/db";
+import { createProduct, createDeliverySlot } from "../helpers/factories";
+import { adminCookieHeader } from "../helpers/auth";
+
+const YEAR = 2027;
+const MONTH = 3; // marzo 2027, elegido fijo para que el test sea determinístico
+
+function countTargetDays(): number {
+  let count = 0;
+  const cursor = new Date(YEAR, MONTH - 1, 1);
+  while (cursor.getMonth() === MONTH - 1) {
+    if (cursor.getDay() === 1 || cursor.getDay() === 6) count++;
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return count;
+}
+
+function postRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/slots/generate", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+describe("POST /api/admin/slots/generate", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await POST(postRequest({ year: YEAR, month: MONTH }));
+    expect(res.status).toBe(401);
+  });
+
+  it("genera un slot por cada lunes y sábado del mes", async () => {
+    const res = await POST(postRequest({ year: YEAR, month: MONTH }, await adminCookieHeader()));
+    const json = await res.json();
+
+    const expected = countTargetDays();
+    expect(json.created).toBe(expected);
+    expect(json.skipped).toBe(0);
+
+    const slots = await prisma.deliverySlot.findMany({
+      where: { date: { gte: new Date(YEAR, MONTH - 1, 1), lte: new Date(YEAR, MONTH, 0, 23, 59, 59) } },
+    });
+    expect(slots).toHaveLength(expected);
+  });
+
+  it("no duplica un slot que ya existe en esa fecha", async () => {
+    const cursor = new Date(YEAR, MONTH - 1, 1);
+    while (cursor.getDay() !== 1) cursor.setDate(cursor.getDate() + 1);
+    const firstMonday = new Date(cursor);
+    firstMonday.setHours(12, 0, 0, 0);
+    await createDeliverySlot({ date: firstMonday, dayLabel: "Ya existía" });
+
+    const res = await POST(postRequest({ year: YEAR, month: MONTH }, await adminCookieHeader()));
+    const json = await res.json();
+
+    const expected = countTargetDays();
+    expect(json.created).toBe(expected - 1);
+    expect(json.skipped).toBe(1);
+  });
+
+  it("inicializa stock solo para productos disponibles ese día de la semana", async () => {
+    const lunesOnly = await createProduct({ availableDays: "lunes" });
+    const sabadoOnly = await createProduct({ availableDays: "sabado" });
+
+    await POST(postRequest({ year: YEAR, month: MONTH }, await adminCookieHeader()));
+
+    const slotsInMonth = await prisma.deliverySlot.findMany({
+      where: { date: { gte: new Date(YEAR, MONTH - 1, 1), lte: new Date(YEAR, MONTH, 0, 23, 59, 59) } },
+    });
+    const mondaySlot = slotsInMonth.find((s) => new Date(s.date).getDay() === 1);
+    const mondayStocks = await prisma.productStock.findMany({ where: { deliverySlotId: mondaySlot!.id } });
+    const stockedProductIds = mondayStocks.map((s) => s.productId);
+
+    expect(stockedProductIds).toContain(lunesOnly.id);
+    expect(stockedProductIds).not.toContain(sabadoOnly.id);
+  });
+});

--- a/tests/integration/admin-slots.test.ts
+++ b/tests/integration/admin-slots.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/admin/slots/route";
+import { PUT, DELETE } from "@/app/api/admin/slots/[id]/route";
+import { prisma } from "@/lib/db";
+import { createProduct, createDeliverySlot, createProductStock } from "../helpers/factories";
+import { adminCookieHeader } from "../helpers/auth";
+
+function getRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/slots", { headers });
+}
+
+function postRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/slots", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+function putRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/slots/1", {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+function deleteRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/slots/1", { method: "DELETE", headers });
+}
+
+describe("GET /api/admin/slots", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve slots activos e inactivos", async () => {
+    await createDeliverySlot({ active: true });
+    await createDeliverySlot({ active: false });
+
+    const res = await GET(getRequest(await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(json).toHaveLength(2);
+  });
+});
+
+describe("POST /api/admin/slots", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await POST(postRequest({ date: "2026-08-10", dayLabel: "Lunes" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("crea el slot e inicializa stock (8 unidades) para cada producto activo", async () => {
+    const active = await createProduct({ active: true });
+    await createProduct({ active: false });
+
+    const res = await POST(
+      postRequest({ date: "2026-08-10", dayLabel: "Lunes", deliveryMode: "pickup" }, await adminCookieHeader())
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+
+    const stocks = await prisma.productStock.findMany({ where: { deliverySlotId: json.id } });
+    expect(stocks).toHaveLength(1);
+    expect(stocks[0].productId).toBe(active.id);
+    expect(stocks[0].totalStock).toBe(8);
+  });
+});
+
+describe("PUT /api/admin/slots/[id]", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await PUT(putRequest({ dayLabel: "Nuevo" }), { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("actualiza los campos del slot", async () => {
+    const slot = await createDeliverySlot({ dayLabel: "Viejo", active: true });
+
+    const res = await PUT(
+      putRequest({ dayLabel: "Actualizado", deliveryMode: "delivery", active: false }, await adminCookieHeader()),
+      { params: Promise.resolve({ id: String(slot.id) }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.dayLabel).toBe("Actualizado");
+    expect(json.active).toBe(false);
+  });
+});
+
+describe("DELETE /api/admin/slots/[id]", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await DELETE(deleteRequest(), { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("elimina el slot y su stock asociado (cascade)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id);
+
+    const res = await DELETE(deleteRequest(await adminCookieHeader()), { params: Promise.resolve({ id: String(slot.id) }) });
+
+    expect(res.status).toBe(200);
+    const remaining = await prisma.deliverySlot.findUnique({ where: { id: slot.id } });
+    expect(remaining).toBeNull();
+    const stocks = await prisma.productStock.findMany({ where: { deliverySlotId: slot.id } });
+    expect(stocks).toHaveLength(0);
+  });
+});

--- a/tests/integration/admin-stock.test.ts
+++ b/tests/integration/admin-stock.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, PUT } from "@/app/api/admin/stock/route";
+import { prisma } from "@/lib/db";
+import { createProduct, createDeliverySlot, createProductStock } from "../helpers/factories";
+import { adminCookieHeader } from "../helpers/auth";
+
+function getRequest(query = "", headers: Record<string, string> = {}) {
+  return new NextRequest(`http://localhost/api/admin/stock${query}`, { headers });
+}
+
+function putRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/stock", {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+describe("GET /api/admin/stock", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve el stock con el disponible calculado", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 3 });
+
+    const res = await GET(getRequest("", await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json[0].available).toBe(7);
+  });
+
+  it("filtra por slotId", async () => {
+    const product = await createProduct();
+    const slotA = await createDeliverySlot();
+    const slotB = await createDeliverySlot();
+    await createProductStock(product.id, slotA.id);
+    await createProductStock(product.id, slotB.id);
+
+    const res = await GET(getRequest(`?slotId=${slotA.id}`, await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(json).toHaveLength(1);
+    expect(json[0].deliverySlotId).toBe(slotA.id);
+  });
+});
+
+describe("PUT /api/admin/stock", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await PUT(putRequest({ productId: 1, deliverySlotId: 1, totalStock: 5 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("crea el registro de stock si no existe", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+
+    const res = await PUT(
+      putRequest({ productId: product.id, deliverySlotId: slot.id, totalStock: 12 }, await adminCookieHeader())
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.totalStock).toBe(12);
+    expect(json.reservedStock).toBe(0);
+  });
+
+  it("actualiza el totalStock si ya existe, sin tocar reservedStock", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5, reservedStock: 2 });
+
+    await PUT(putRequest({ productId: product.id, deliverySlotId: slot.id, totalStock: 20 }, await adminCookieHeader()));
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    expect(stock?.totalStock).toBe(20);
+    expect(stock?.reservedStock).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Integration tests contra Postgres real para las rutas de admin: `GET/PATCH /api/admin/orders(/[id])`, `GET/PUT /api/admin/stock`, `GET/POST /api/admin/slots`, `PUT/DELETE /api/admin/slots/[id]`, `POST /api/admin/slots/generate`.
- Nuevo helper `tests/helpers/auth.ts` que firma un JWT admin válido (vía `signToken` de `lib/auth.ts`) y arma el header `Cookie` para simular sesión de admin en `NextRequest`, ya que `requireAdmin` lee la cookie directo del request.
- Nuevo factory `createOrder` en `tests/helpers/factories.ts`.
- Reusa toda la infra de Vitest + Postgres real de Prioridad 1 (sin cambios en `vitest.config.ts` / `tests/setup.ts` / CI).

## Test plan
- [x] `npm run test:db:up && npm test` — 46/46 tests pasan (21 de Prioridad 1 + 25 nuevos)
- [x] `npx eslint tests` — sin errores
- [x] `npx tsc --noEmit` — sin errores
- [ ] Confirmar CI en verde en este PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)