### PR TITLE
chore: integration tests para catálogo y auth de admin (Prioridad 3)

### DIFF
--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,0 +1,6 @@
+import { signToken } from "@/lib/auth";
+
+export async function adminCookieHeader(): Promise<{ cookie: string }> {
+  const token = await signToken({ admin: true });
+  return { cookie: `admin_token=${token}` };
+}

--- a/tests/integration/admin-auth.test.ts
+++ b/tests/integration/admin-auth.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { POST as login } from "@/app/api/admin/login/route";
+import { POST as logout } from "@/app/api/admin/logout/route";
+import { verifyToken } from "@/lib/auth";
+
+const CORRECT_PASSWORD = process.env.ADMIN_PASSWORD ?? "brot74admin";
+
+function loginRequest(password: string) {
+  return new NextRequest("http://localhost/api/admin/login", {
+    method: "POST",
+    body: JSON.stringify({ password }),
+  });
+}
+
+describe("POST /api/admin/login", () => {
+  it("devuelve 401 con contraseña incorrecta y no setea cookie", async () => {
+    const res = await login(loginRequest("contraseña-incorrecta-obviamente"));
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("devuelve 200 y setea una cookie admin_token válida con la contraseña correcta", async () => {
+    const res = await login(loginRequest(CORRECT_PASSWORD));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("admin_token=");
+    expect(setCookie).toContain("HttpOnly");
+
+    const token = res.cookies.get("admin_token")?.value ?? "";
+    const payload = await verifyToken(token);
+    expect(payload).not.toBeNull();
+  });
+});
+
+describe("POST /api/admin/logout", () => {
+  it("limpia la cookie admin_token", async () => {
+    const res = await logout();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("admin_token=");
+    expect(setCookie).toMatch(/Max-Age=0/i);
+  });
+});

--- a/tests/integration/admin-products.test.ts
+++ b/tests/integration/admin-products.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/admin/products/route";
+import { PUT, DELETE } from "@/app/api/admin/products/[id]/route";
+import { prisma } from "@/lib/db";
+import { createProduct, createDeliverySlot, createProductStock } from "../helpers/factories";
+import { adminCookieHeader } from "../helpers/auth";
+
+function getRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/products", { headers });
+}
+
+function postRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/products", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+function putRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/products/1", {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+function deleteRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/products/1", { method: "DELETE", headers });
+}
+
+function nextMondayAt(hoursFromNow: number) {
+  const d = new Date(Date.now() + hoursFromNow * 60 * 60 * 1000);
+  while (d.getDay() !== 1) d.setDate(d.getDate() + 1);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+describe("GET /api/admin/products", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve productos activos e inactivos, ordenados por sortOrder", async () => {
+    await createProduct({ name: "B", sortOrder: 1, active: false });
+    await createProduct({ name: "A", sortOrder: 0, active: true });
+
+    const res = await GET(getRequest(await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(json.map((p: { name: string }) => p.name)).toEqual(["A", "B"]);
+  });
+});
+
+describe("POST /api/admin/products", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await POST(postRequest({ name: "Nuevo", price: 1000 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("crea el producto con los defaults esperados", async () => {
+    const res = await POST(postRequest({ name: "Nuevo", price: "1500" }, await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.name).toBe("Nuevo");
+    expect(json.price).toBe(1500);
+    expect(json.active).toBe(true);
+    expect(json.focalX).toBe(50);
+  });
+});
+
+describe("PUT /api/admin/products/[id]", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await PUT(putRequest({ name: "X", price: 1000 }), { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("actualiza los campos básicos del producto", async () => {
+    const product = await createProduct({ name: "Viejo", price: 1000, availableDays: "" });
+
+    const res = await PUT(
+      putRequest({ name: "Actualizado", price: 2000, availableDays: "" }, await adminCookieHeader()),
+      { params: Promise.resolve({ id: String(product.id) }) }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.name).toBe("Actualizado");
+    expect(json.price).toBe(2000);
+  });
+
+  it("al agregar un día disponible, inicializa stock (5) en slots futuros de ese día", async () => {
+    const product = await createProduct({ availableDays: "" });
+    const mondaySlot = await createDeliverySlot({ date: nextMondayAt(24) });
+
+    await PUT(putRequest({ name: product.name, price: product.price, availableDays: "lunes" }, await adminCookieHeader()), {
+      params: Promise.resolve({ id: String(product.id) }),
+    });
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: mondaySlot.id } },
+    });
+    expect(stock?.totalStock).toBe(5);
+  });
+
+  it("al quitar un día disponible, pone en 0 el stock de slots futuros de ese día", async () => {
+    const product = await createProduct({ availableDays: "lunes" });
+    const mondaySlot = await createDeliverySlot({ date: nextMondayAt(24) });
+    await createProductStock(product.id, mondaySlot.id, { totalStock: 8, reservedStock: 0 });
+
+    await PUT(putRequest({ name: product.name, price: product.price, availableDays: "" }, await adminCookieHeader()), {
+      params: Promise.resolve({ id: String(product.id) }),
+    });
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: mondaySlot.id } },
+    });
+    expect(stock?.totalStock).toBe(0);
+  });
+
+  it("no toca el stock de slots que ya pasaron", async () => {
+    const product = await createProduct({ availableDays: "" });
+    const pastMonday = await createDeliverySlot({ date: nextMondayAt(-7 * 24) });
+
+    await PUT(putRequest({ name: product.name, price: product.price, availableDays: "lunes" }, await adminCookieHeader()), {
+      params: Promise.resolve({ id: String(product.id) }),
+    });
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: pastMonday.id } },
+    });
+    expect(stock).toBeNull();
+  });
+
+  it("no modifica el stock si la disponibilidad del día no cambió", async () => {
+    const product = await createProduct({ availableDays: "lunes" });
+    const mondaySlot = await createDeliverySlot({ date: nextMondayAt(24) });
+    await createProductStock(product.id, mondaySlot.id, { totalStock: 8, reservedStock: 1 });
+
+    await PUT(putRequest({ name: product.name, price: product.price, availableDays: "lunes" }, await adminCookieHeader()), {
+      params: Promise.resolve({ id: String(product.id) }),
+    });
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: mondaySlot.id } },
+    });
+    expect(stock?.totalStock).toBe(8);
+    expect(stock?.reservedStock).toBe(1);
+  });
+});
+
+describe("DELETE /api/admin/products/[id]", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await DELETE(deleteRequest(), { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("elimina el producto", async () => {
+    const product = await createProduct();
+
+    const res = await DELETE(deleteRequest(await adminCookieHeader()), { params: Promise.resolve({ id: String(product.id) }) });
+
+    expect(res.status).toBe(200);
+    const remaining = await prisma.product.findUnique({ where: { id: product.id } });
+    expect(remaining).toBeNull();
+  });
+});

--- a/tests/integration/products.test.ts
+++ b/tests/integration/products.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/products/route";
+import { createProduct, createDeliverySlot, createProductStock, createCartReservation } from "../helpers/factories";
+
+function getRequest(query = "") {
+  return new NextRequest(`http://localhost/api/products${query}`);
+}
+
+describe("GET /api/products", () => {
+  it("solo devuelve productos activos, ordenados por sortOrder", async () => {
+    await createProduct({ name: "Segundo", sortOrder: 2, active: true });
+    await createProduct({ name: "Inactivo", sortOrder: 0, active: false });
+    await createProduct({ name: "Primero", sortOrder: 1, active: true });
+
+    const res = await GET(getRequest());
+    const json = await res.json();
+
+    expect(json.map((p: { name: string }) => p.name)).toEqual(["Primero", "Segundo"]);
+  });
+
+  it("sin slotId, devuelve stock null y hasStock true", async () => {
+    await createProduct();
+
+    const res = await GET(getRequest());
+    const json = await res.json();
+
+    expect(json[0].stock).toBeNull();
+    expect(json[0].hasStock).toBe(true);
+  });
+
+  it("con slotId, calcula el stock disponible descontando reservas de carrito activas", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 2 });
+    await createCartReservation(product.id, slot.id, { quantity: 3 });
+
+    const res = await GET(getRequest(`?slotId=${slot.id}`));
+    const json = await res.json();
+
+    expect(json[0].stock).toBe(5);
+    expect(json[0].hasStock).toBe(true);
+  });
+
+  it("con slotId, ignora reservas de carrito expiradas", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5, reservedStock: 0 });
+    await createCartReservation(product.id, slot.id, { quantity: 5, expiresAt: new Date(Date.now() - 1000) });
+
+    const res = await GET(getRequest(`?slotId=${slot.id}`));
+    const json = await res.json();
+
+    expect(json[0].stock).toBe(5);
+    expect(json[0].hasStock).toBe(true);
+  });
+
+  it("con slotId, un producto sin registro de stock queda con stock null y hasStock true", async () => {
+    await createProduct();
+    const slot = await createDeliverySlot();
+
+    const res = await GET(getRequest(`?slotId=${slot.id}`));
+    const json = await res.json();
+
+    expect(json[0].stock).toBeNull();
+    expect(json[0].hasStock).toBe(true);
+  });
+
+  it("con slotId, hasStock es false cuando el disponible es 0", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 2, reservedStock: 2 });
+
+    const res = await GET(getRequest(`?slotId=${slot.id}`));
+    const json = await res.json();
+
+    expect(json[0].stock).toBe(0);
+    expect(json[0].hasStock).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Integration tests contra Postgres real para `GET /api/products` (catálogo público), el CRUD de `admin/products` (incluyendo el efecto secundario de `availableDays` sobre el stock de slots futuros) y `admin/login` / `admin/logout`.
- Reusa `tests/helpers/auth.ts` (mismo helper que agregó el PR de Prioridad 2 — se recreó acá porque esta rama se creó desde `main` antes de que ese PR se mergeara; el contenido es idéntico así que no debería generar conflicto al mergear).

## Test plan
- [x] `npm run test:db:up && npm test` — 42/42 tests pasan (21 de Prioridad 1 + 21 nuevos)
- [x] `npx eslint tests` — sin errores
- [x] `npx tsc --noEmit` — sin errores
- [ ] Confirmar CI en verde en este PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)