### PR TITLE
chore: integration tests para waitlist, upload y cron (Prioridad 4)

### DIFF
--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,0 +1,6 @@
+import { signToken } from "@/lib/auth";
+
+export async function adminCookieHeader(): Promise<{ cookie: string }> {
+  const token = await signToken({ admin: true });
+  return { cookie: `admin_token=${token}` };
+}

--- a/tests/integration/admin-images.test.ts
+++ b/tests/integration/admin-images.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("fs", () => ({
+  default: { readdirSync: vi.fn() },
+}));
+
+import { GET } from "@/app/api/admin/images/route";
+import fs from "fs";
+import { adminCookieHeader } from "../helpers/auth";
+
+function getRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/admin/images", { headers });
+}
+
+describe("GET /api/admin/images", () => {
+  it("devuelve 401 sin sesión de admin", async () => {
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve solo archivos de imagen, mapeados a /products/<archivo>", async () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      "producto-1.jpg",
+      "producto-2.PNG",
+      "producto-3.webp",
+      "notas.txt",
+      ".DS_Store",
+    ] as never);
+
+    const res = await GET(getRequest(await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual(["/products/producto-1.jpg", "/products/producto-2.PNG", "/products/producto-3.webp"]);
+  });
+});

--- a/tests/integration/admin-upload.test.ts
+++ b/tests/integration/admin-upload.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@vercel/blob", () => ({
+  put: vi.fn(),
+}));
+
+import { POST } from "@/app/api/admin/upload/route";
+import { put } from "@vercel/blob";
+import { adminCookieHeader } from "../helpers/auth";
+
+// PNG 1x1 transparente válido
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64"
+);
+
+async function uploadRequest(file: File | null, extraHeaders: Record<string, string> = {}) {
+  const formData = new FormData();
+  if (file) formData.append("file", file);
+  return new NextRequest("http://localhost/api/admin/upload", {
+    method: "POST",
+    body: formData,
+    headers: extraHeaders,
+  });
+}
+
+describe("POST /api/admin/upload", () => {
+  beforeEach(() => {
+    vi.mocked(put).mockReset();
+  });
+
+  it("devuelve 401 sin sesión de admin", async () => {
+    const file = new File([TINY_PNG], "foto.png", { type: "image/png" });
+    const res = await POST(await uploadRequest(file));
+    expect(res.status).toBe(401);
+  });
+
+  it("devuelve 400 si no se envía ningún archivo", async () => {
+    const res = await POST(await uploadRequest(null, await adminCookieHeader()));
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 para archivos HEIC/HEIF", async () => {
+    const file = new File([TINY_PNG], "foto.heic", { type: "image/heic" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 para un tipo de archivo no permitido", async () => {
+    const file = new File([TINY_PNG], "foto.gif", { type: "image/gif" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 si el archivo pesa más de 5MB", async () => {
+    const big = Buffer.alloc(6 * 1024 * 1024);
+    const file = new File([big], "foto.png", { type: "image/png" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 si la imagen está corrupta", async () => {
+    const garbage = Buffer.from("esto no es una imagen de verdad");
+    const file = new File([garbage], "foto.jpg", { type: "image/jpeg" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+    expect(res.status).toBe(400);
+  });
+
+  it("optimiza y sube la imagen, devolviendo la URL del blob", async () => {
+    vi.mocked(put).mockResolvedValue({ url: "https://blob.example/products/product-123.webp" } as never);
+
+    const file = new File([TINY_PNG], "foto.png", { type: "image/png" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.url).toBe("https://blob.example/products/product-123.webp");
+
+    const [filename, , options] = vi.mocked(put).mock.calls[0];
+    expect(filename).toMatch(/^products\/product-\d+\.webp$/);
+    expect(options).toMatchObject({ contentType: "image/webp" });
+  });
+});

--- a/tests/integration/cron-cleanup.test.ts
+++ b/tests/integration/cron-cleanup.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/cron/cleanup/route";
+import { prisma } from "@/lib/db";
+import { createProduct, createDeliverySlot, createCartReservation } from "../helpers/factories";
+
+const originalCronSecret = process.env.CRON_SECRET;
+
+function getRequest(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost/api/cron/cleanup", { headers });
+}
+
+afterEach(() => {
+  if (originalCronSecret === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = originalCronSecret;
+});
+
+describe("GET /api/cron/cleanup", () => {
+  it("borra solo las reservas de carrito expiradas", async () => {
+    delete process.env.CRON_SECRET;
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createCartReservation(product.id, slot.id, { expiresAt: new Date(Date.now() - 60_000) });
+    const active = await createCartReservation(product.id, slot.id, { expiresAt: new Date(Date.now() + 60_000) });
+
+    const res = await GET(getRequest());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.deleted).toBe(1);
+
+    const remaining = await prisma.cartReservation.findMany();
+    expect(remaining.map((r) => r.id)).toEqual([active.id]);
+  });
+
+  it("sin CRON_SECRET configurado, no exige autorización", async () => {
+    delete process.env.CRON_SECRET;
+
+    const res = await GET(getRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it("con CRON_SECRET configurado, devuelve 401 sin el header correcto", async () => {
+    process.env.CRON_SECRET = "mi-secreto";
+
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("con CRON_SECRET configurado, devuelve 200 con el Bearer correcto", async () => {
+    process.env.CRON_SECRET = "mi-secreto";
+
+    const res = await GET(getRequest({ authorization: "Bearer mi-secreto" }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/integration/waitlist.test.ts
+++ b/tests/integration/waitlist.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/waitlist/route";
+import { prisma } from "@/lib/db";
+
+function postRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/waitlist", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/waitlist", () => {
+  it("crea la entrada limpiando el número a solo dígitos", async () => {
+    const res = await POST(postRequest({ phone: "+54 9 11 2233-4455" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.ok).toBe(true);
+
+    const entries = await prisma.waitlistEntry.findMany();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].phone).toBe("5491122334455");
+  });
+
+  it("devuelve 400 si el número tiene menos de 7 dígitos", async () => {
+    const res = await POST(postRequest({ phone: "12345" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 si el número tiene más de 15 dígitos", async () => {
+    const res = await POST(postRequest({ phone: "1234567890123456" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 si no llega ningún número", async () => {
+    const res = await POST(postRequest({}));
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Completa la cobertura de integration tests planeada (Prioridad 4 de 4): `POST /api/waitlist`, `POST /api/admin/upload`, `GET /api/admin/images` y `GET /api/cron/cleanup`.
- `admin/upload`: mockea `@vercel/blob` (`put`) para no pegarle a Blob real; cubre HEIC rechazado, tipo inválido, tamaño excedido, imagen corrupta (consistente con BRT-65) y el flujo exitoso.
- `admin/images`: mockea `fs.readdirSync` para no depender ni tocar los archivos reales de `public/products`.
- `cron/cleanup`: cubre el caso con y sin `CRON_SECRET` configurado.
- Reusa `tests/helpers/auth.ts` (mismo contenido que en los PRs de Prioridad 2 y 3 — se recreó por la misma razón de ramificación independiente desde `main`).

Con esto quedan cubiertas las 13 rutas de la lista original de integration tests.

## Test plan
- [x] `npm run test:db:up && npm test` — 38/38 tests pasan (21 de Prioridad 1 + 17 nuevos)
- [x] `npx eslint tests` — sin errores
- [x] `npx tsc --noEmit` — sin errores
- [ ] Confirmar CI en verde en este PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)