### PR TITLE
fix: subir imágenes de fechas a carpeta dates/ (BRT-66)

### DIFF
--- a/app/admin/(panel)/fechas/page.tsx
+++ b/app/admin/(panel)/fechas/page.tsx
@@ -565,6 +565,7 @@ function SlotImageTrigger({ slot, images, onSave }: {
     try {
       const fd = new FormData();
       fd.append("file", file);
+      fd.append("folder", "dates");
       const res = await fetch("/api/admin/upload", { method: "POST", body: fd });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {

--- a/app/admin/(panel)/productos/page.tsx
+++ b/app/admin/(panel)/productos/page.tsx
@@ -111,6 +111,7 @@ export default function ProductosPage() {
     try {
       const fd = new FormData();
       fd.append("file", file);
+      fd.append("folder", "products");
       const res = await fetch("/api/admin/upload", { method: "POST", body: fd });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {

--- a/app/api/admin/upload/route.ts
+++ b/app/api/admin/upload/route.ts
@@ -5,6 +5,8 @@ import sharp from "sharp";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const HEIC_EXTENSIONS = ["heic", "heif"];
+const ALLOWED_FOLDERS = ["products", "dates"] as const;
+type UploadFolder = (typeof ALLOWED_FOLDERS)[number];
 const MAX_ORIGINAL_BYTES = 5 * 1024 * 1024; // 5MB
 const MAX_WIDTH = 1200;
 const TARGET_BYTES = 150 * 1024; // 150KB, con margen bajo el límite de 200KB del ticket
@@ -29,6 +31,10 @@ export async function POST(req: NextRequest) {
 
   const formData = await req.formData();
   const file = formData.get("file") as File | null;
+  const folderInput = formData.get("folder");
+  const folder: UploadFolder = ALLOWED_FOLDERS.includes(folderInput as UploadFolder)
+    ? (folderInput as UploadFolder)
+    : "products";
 
   if (!file) return NextResponse.json({ error: "No se recibió archivo" }, { status: 400 });
 
@@ -61,7 +67,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "El archivo está dañado o no es una imagen válida." }, { status: 400 });
   }
 
-  const filename = `products/product-${Date.now()}.webp`;
+  const filename = `${folder}/${folder === "dates" ? "date" : "product"}-${Date.now()}.webp`;
 
   try {
     const blob = await put(filename, optimized, { access: "public", contentType: "image/webp" });

--- a/tests/integration/admin-upload.test.ts
+++ b/tests/integration/admin-upload.test.ts
@@ -15,9 +15,14 @@ const TINY_PNG = Buffer.from(
   "base64"
 );
 
-async function uploadRequest(file: File | null, extraHeaders: Record<string, string> = {}) {
+async function uploadRequest(
+  file: File | null,
+  extraHeaders: Record<string, string> = {},
+  folder?: string
+) {
   const formData = new FormData();
   if (file) formData.append("file", file);
+  if (folder) formData.append("folder", folder);
   return new NextRequest("http://localhost/api/admin/upload", {
     method: "POST",
     body: formData,
@@ -71,7 +76,7 @@ describe("POST /api/admin/upload", () => {
     vi.mocked(put).mockResolvedValue({ url: "https://blob.example/products/product-123.webp" } as never);
 
     const file = new File([TINY_PNG], "foto.png", { type: "image/png" });
-    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+    const res = await POST(await uploadRequest(file, await adminCookieHeader(), "products"));
     const json = await res.json();
 
     expect(res.status).toBe(200);
@@ -80,5 +85,38 @@ describe("POST /api/admin/upload", () => {
     const [filename, , options] = vi.mocked(put).mock.calls[0];
     expect(filename).toMatch(/^products\/product-\d+\.webp$/);
     expect(options).toMatchObject({ contentType: "image/webp" });
+  });
+
+  it("sin folder explícito, sube a products/ (compatibilidad)", async () => {
+    vi.mocked(put).mockResolvedValue({ url: "https://blob.example/products/product-123.webp" } as never);
+
+    const file = new File([TINY_PNG], "foto.png", { type: "image/png" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader()));
+
+    expect(res.status).toBe(200);
+    const [filename] = vi.mocked(put).mock.calls[0];
+    expect(filename).toMatch(/^products\/product-\d+\.webp$/);
+  });
+
+  it("con folder=dates, sube la imagen a la carpeta dates/", async () => {
+    vi.mocked(put).mockResolvedValue({ url: "https://blob.example/dates/date-123.webp" } as never);
+
+    const file = new File([TINY_PNG], "foto.png", { type: "image/png" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader(), "dates"));
+
+    expect(res.status).toBe(200);
+    const [filename] = vi.mocked(put).mock.calls[0];
+    expect(filename).toMatch(/^dates\/date-\d+\.webp$/);
+  });
+
+  it("con un folder no reconocido, cae de vuelta a products/", async () => {
+    vi.mocked(put).mockResolvedValue({ url: "https://blob.example/products/product-123.webp" } as never);
+
+    const file = new File([TINY_PNG], "foto.png", { type: "image/png" });
+    const res = await POST(await uploadRequest(file, await adminCookieHeader(), "../../etc"));
+
+    expect(res.status).toBe(200);
+    const [filename] = vi.mocked(put).mock.calls[0];
+    expect(filename).toMatch(/^products\/product-\d+\.webp$/);
   });
 });


### PR DESCRIPTION
## Resumen
- El endpoint compartido `POST /api/admin/upload` hardcodeaba `products/` como carpeta destino de toda subida, sin importar el panel de origen.
- Ahora acepta un campo `folder` explícito en el FormData (`products` o `dates`), con fallback a `products` si no se envía o es inválido.
- El panel de productos envía `folder=products`, el panel de fechas envía `folder=dates`.
- Las imágenes ya guardadas en `products/` no requieren migración (sin cambios).

Fixes [BRT-66](https://brot74.atlassian.net/browse/BRT-66).

## Test plan
- [x] `npx vitest run tests/integration/admin-upload.test.ts` — 10/10 pasan, incluye casos nuevos para `dates/`, fallback sin folder y folder inválido.
- [x] `npx vitest run` (suite completa) — 87/87 pasan.
- [x] `npx tsc --noEmit` — sin errores.

[BRT-66]: https://brot74.atlassian.net/browse/BRT-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ