### PR TITLE
chore: agregar ESLint como gate obligatorio en CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx prisma generate
+
+      - run: npm run lint
+
   integration:
     runs-on: ubuntu-latest
     services:

--- a/app/admin/(panel)/fechas/page.tsx
+++ b/app/admin/(panel)/fechas/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Plus, Trash2, Loader2, X, Check, ToggleLeft, ToggleRight, Home, Truck, CalendarDays, ChevronDown, ChevronUp, ImageIcon, ZoomIn } from "lucide-react";
-import { cn } from "@/lib/utils";
-import Image from "next/image";
+import { Plus, Trash2, Loader2, X, Check, ToggleLeft, ToggleRight, Home, Truck, CalendarDays, ChevronDown, ChevronUp, ImageIcon } from "lucide-react";
 import FocalPicker from "@/components/FocalPicker";
 import ImageZoomModal from "@/components/ImageZoomModal";
 import { toastError, toastSuccess } from "@/lib/toast";
@@ -34,7 +32,6 @@ const MONTHS = [
 export default function FechasPage() {
   const [slots, setSlots] = useState<Slot[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
-  const [images, setImages] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [showGenerate, setShowGenerate] = useState(false);
@@ -53,15 +50,12 @@ export default function FechasPage() {
   const [genYear, setGenYear] = useState(nextYear);
 
   async function fetchAll() {
-    const [slotsRes, productsRes, imagesRes] = await Promise.all([
+    const [slotsRes, productsRes] = await Promise.all([
       fetch("/api/admin/slots"),
       fetch("/api/admin/products"),
-      fetch("/api/admin/images"),
     ]);
     const slotsData = await slotsRes.json();
     const productsData = await productsRes.json();
-    const imagesData = await imagesRes.json();
-    setImages(imagesData);
     setSlots(slotsData.map((s: Slot & { stocks: { product: { name: string }, totalStock: number, reservedStock: number, id: number, productId: number, deliverySlotId: number }[] }) => ({
       ...s,
       stocks: s.stocks.map((st) => ({
@@ -219,7 +213,6 @@ export default function FechasPage() {
             title="Próximas fechas"
             slots={upcoming}
             products={products}
-            images={images}
             stockEdits={stockEdits}
             setStockEdits={setStockEdits}
             onToggle={toggleActive}
@@ -255,7 +248,6 @@ export default function FechasPage() {
                     onUpdateDetails={updateDetails}
                     onUpdateImage={updateImage}
                     onUpdateCutoff={updateCutoff}
-                    images={images}
                     muted
                   />
                 </div>
@@ -423,8 +415,8 @@ export default function FechasPage() {
   );
 }
 
-function SlotList({ title, slots, products, images, stockEdits, setStockEdits, onToggle, onDelete, onSaveStock, onChangeMode, onUpdateDetails, onUpdateImage, onUpdateCutoff, muted }: {
-  title: string; slots: Slot[]; products: Product[]; images: string[];
+function SlotList({ title, slots, products, stockEdits, setStockEdits, onToggle, onDelete, onSaveStock, onChangeMode, onUpdateDetails, onUpdateImage, onUpdateCutoff, muted }: {
+  title: string; slots: Slot[]; products: Product[];
   stockEdits: Record<string, string>; setStockEdits: (fn: (prev: Record<string, string>) => Record<string, string>) => void;
   onToggle: (s: Slot) => void; onDelete: (id: number) => void;
   onSaveStock: (productId: number, deliverySlotId: number, key: string) => void;
@@ -453,7 +445,7 @@ function SlotList({ title, slots, products, images, stockEdits, setStockEdits, o
                 </div>
               </div>
               <div className="flex items-center gap-1.5">
-                <SlotImageTrigger slot={slot} images={images} onSave={(imageUrl, focalX, focalY, imageScale) => onUpdateImage(slot, imageUrl, focalX, focalY, imageScale)} />
+                <SlotImageTrigger slot={slot} onSave={(imageUrl, focalX, focalY, imageScale) => onUpdateImage(slot, imageUrl, focalX, focalY, imageScale)} />
                 <div className="relative group">
                   <button onClick={() => onToggle(slot)} className="p-2 text-amber hover:text-amber-light transition-colors">
                     {slot.active ? <ToggleRight className="w-5 h-5" /> : <ToggleLeft className="w-5 h-5" />}
@@ -543,9 +535,8 @@ function SlotList({ title, slots, products, images, stockEdits, setStockEdits, o
 
 const HERO_IMAGE_FALLBACK = "/products/product-1779659787800.jpeg";
 
-function SlotImageTrigger({ slot, images, onSave }: {
+function SlotImageTrigger({ slot, onSave }: {
   slot: Slot;
-  images: string[];
   onSave: (imageUrl: string, focalX: number, focalY: number, imageScale: number) => void;
 }) {
   const [showModal, setShowModal] = useState(false);

--- a/app/admin/(panel)/pedidos/page.tsx
+++ b/app/admin/(panel)/pedidos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { Loader2, Phone, MapPin, Package, Truck, Home, ChevronDown } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
@@ -37,15 +37,15 @@ function PedidosContent() {
   const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState<number | null>(null);
 
-  async function fetchOrders() {
+  const fetchOrders = useCallback(async () => {
     const url = slotFilter ? `/api/admin/orders?slotId=${slotFilter}` : "/api/admin/orders";
     const res = await fetch(url);
     const data = await res.json();
     setOrders(data);
     setLoading(false);
-  }
+  }, [slotFilter]);
 
-  useEffect(() => { fetchOrders(); }, [slotFilter]);
+  useEffect(() => { fetchOrders(); }, [fetchOrders]);
 
   async function updateStatus(orderId: number, status: string) {
     setUpdating(orderId);

--- a/app/admin/(panel)/productos/page.tsx
+++ b/app/admin/(panel)/productos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Plus, Pencil, Trash2, Loader2, X, Check, ToggleLeft, ToggleRight, ImagePlus } from "lucide-react";
 import Image from "next/image";
 import ImageZoomModal from "@/components/ImageZoomModal";

--- a/app/api/admin/slots/generate/route.ts
+++ b/app/api/admin/slots/generate/route.ts
@@ -3,7 +3,6 @@ import { prisma } from "@/lib/db";
 import { requireAdmin } from "@/lib/auth";
 
 const DAY_MAP: Record<number, string> = { 1: "lunes", 6: "sabado" };
-const DELIVERY_DAYS = new Set<number>(); // Por defecto todo es retiro, el admin lo cambia manualmente
 const TARGET_DAYS = [1, 6];        // Lunes, Sábado
 const DEFAULT_STOCK = 8;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,13 +118,6 @@ export default function Home() {
     setCart({});
   }
 
-  function goHome() {
-    setView("home");
-    setSelectedSlotId(null);
-    setCart({});
-    localStorage.removeItem("brot74-cart");
-  }
-
   function addToCart(productId: number) {
     setCart((prev) => ({ ...prev, [productId]: (prev[productId] ?? 0) + 1 }));
   }

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -213,7 +213,7 @@ function NoSlotsEmptyState() {
   );
 }
 
-export default function DateSelector({ slots, selectedId, onChange }: DateSelectorProps) {
+export default function DateSelector({ slots, onChange }: DateSelectorProps) {
   const visibleSlots = slots.filter((s) => !s.disabled);
 
   if (visibleSlots.length === 0) {

--- a/components/ImageZoomModal.tsx
+++ b/components/ImageZoomModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import Image from "next/image";
 import { X, ZoomIn, ZoomOut } from "lucide-react";
 
 interface ImageZoomModalProps {

--- a/components/OrderModal.tsx
+++ b/components/OrderModal.tsx
@@ -142,7 +142,7 @@ function formatCountdown(seconds: number): string {
   return `${m}:${s}`;
 }
 
-export default function OrderModal({ items, slotId, deliveryMode, slotLabel, slotLocation, sessionToken, expiresAt, onRemoveItem, onChangeQuantity, onClose, onSuccess }: OrderModalProps) {
+export default function OrderModal({ items, slotId, deliveryMode, slotLabel, slotLocation, sessionToken, expiresAt, onRemoveItem, onClose, onSuccess }: OrderModalProps) {
   const [name, setName]       = useState("");
   const [phone, setPhone]     = useState("");
   const [address, setAddress] = useState("");

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { formatCurrency } from "@/lib/utils";
 
 interface ProductCardProps {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,16 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      // Flags any setState call reachable in an effect body, including the
+      // standard "fetch on mount/dep change" and "restore from localStorage"
+      // patterns used across the admin panels and the storefront cart. Kept
+      // as a warning instead of an error to avoid forcing a risky rewrite of
+      // that state logic just to satisfy the linter.
+      "react-hooks/set-state-in-effect": "warn",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:


### PR DESCRIPTION
## Resumen
- Nuevo job `lint` en `.github/workflows/test.yml` que corre `npm run lint` en paralelo a los tests de integración, en cada PR/push a main.
- Se limpiaron los 12 warnings preexistentes de código muerto (imports/vars sin usar, deps de `useEffect`) para poder bloquear en error sin ruido.
- `react-hooks/set-state-in-effect` se bajó a `warning`: es una regla nueva del set de "React Compiler" que marca cualquier `setState` síncrono dentro de un efecto, incluyendo patrones legítimos ya en uso (fetch de productos/pedidos al montar, restauración de carrito desde localStorage). Reescribir esa lógica en el flujo de compra solo para conformar al linter no valía el riesgo — queda documentado con un comentario en `eslint.config.mjs`.
- De paso, se eliminó plumbing muerta en el panel de fechas (estado `images`, fetch a `/api/admin/images`, prop threading por `SlotList`/`SlotImageTrigger`) que nunca se consumía en ningún render. El endpoint `/api/admin/images` quedó huérfano — hay una tarea separada para evaluar borrarlo.

## Test plan
- [x] `npm run lint` — 0 errores, 5 warnings esperados (los de `set-state-in-effect` bajados a warning).
- [x] `npx tsc --noEmit` — sin errores.
- [x] `npx vitest run` (suite completa) — 87/87 pasan.