### PR TITLE
chore: agregar ESLint como gate obligatorio en CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx prisma generate
+
+      - run: npm run lint
+
   integration:
     runs-on: ubuntu-latest
     services:

--- a/app/admin/(panel)/fechas/page.tsx
+++ b/app/admin/(panel)/fechas/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Plus, Trash2, Loader2, X, Check, ToggleLeft, ToggleRight, Home, CalendarDays, ChevronDown, ChevronUp, ImageIcon, ZoomIn } from "lucide-react";
-import { cn } from "@/lib/utils";
-import Image from "next/image";
+import { Plus, Trash2, Loader2, X, Check, ToggleLeft, ToggleRight, Home, CalendarDays, ChevronDown, ChevronUp, ImageIcon } from "lucide-react";
 import FocalPicker from "@/components/FocalPicker";
 import ImageZoomModal from "@/components/ImageZoomModal";
 import { toastError, toastSuccess } from "@/lib/toast";
@@ -33,7 +31,6 @@ const MONTHS = [
 export default function FechasPage() {
   const [slots, setSlots] = useState<Slot[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
-  const [images, setImages] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [showGenerate, setShowGenerate] = useState(false);
@@ -52,15 +49,12 @@ export default function FechasPage() {
   const [genYear, setGenYear] = useState(nextYear);
 
   async function fetchAll() {
-    const [slotsRes, productsRes, imagesRes] = await Promise.all([
+    const [slotsRes, productsRes] = await Promise.all([
       fetch("/api/admin/slots"),
       fetch("/api/admin/products"),
-      fetch("/api/admin/images"),
     ]);
     const slotsData = await slotsRes.json();
     const productsData = await productsRes.json();
-    const imagesData = await imagesRes.json();
-    setImages(imagesData);
     setSlots(slotsData.map((s: Slot & { stocks: { product: { name: string }, totalStock: number, reservedStock: number, id: number, productId: number, deliverySlotId: number }[] }) => ({
       ...s,
       stocks: s.stocks.map((st) => ({
@@ -209,7 +203,6 @@ export default function FechasPage() {
             title="Próximas fechas"
             slots={upcoming}
             products={products}
-            images={images}
             stockEdits={stockEdits}
             setStockEdits={setStockEdits}
             onToggle={toggleActive}
@@ -243,7 +236,6 @@ export default function FechasPage() {
                     onUpdateDetails={updateDetails}
                     onUpdateImage={updateImage}
                     onUpdateCutoff={updateCutoff}
-                    images={images}
                     muted
                   />
                 </div>
@@ -399,8 +391,8 @@ export default function FechasPage() {
   );
 }
 
-function SlotList({ title, slots, products, images, stockEdits, setStockEdits, onToggle, onDelete, onSaveStock, onUpdateDetails, onUpdateImage, onUpdateCutoff, muted }: {
-  title: string; slots: Slot[]; products: Product[]; images: string[];
+function SlotList({ title, slots, products, stockEdits, setStockEdits, onToggle, onDelete, onSaveStock, onUpdateDetails, onUpdateImage, onUpdateCutoff, muted }: {
+  title: string; slots: Slot[]; products: Product[];
   stockEdits: Record<string, string>; setStockEdits: (fn: (prev: Record<string, string>) => Record<string, string>) => void;
   onToggle: (s: Slot) => void; onDelete: (id: number) => void;
   onSaveStock: (productId: number, deliverySlotId: number, key: string) => void;
@@ -428,7 +420,7 @@ function SlotList({ title, slots, products, images, stockEdits, setStockEdits, o
                 </div>
               </div>
               <div className="flex items-center gap-1.5">
-                <SlotImageTrigger slot={slot} images={images} onSave={(imageUrl, focalX, focalY, imageScale) => onUpdateImage(slot, imageUrl, focalX, focalY, imageScale)} />
+                <SlotImageTrigger slot={slot} onSave={(imageUrl, focalX, focalY, imageScale) => onUpdateImage(slot, imageUrl, focalX, focalY, imageScale)} />
                 <div className="relative group">
                   <button onClick={() => onToggle(slot)} className="p-2 text-amber hover:text-amber-light transition-colors">
                     {slot.active ? <ToggleRight className="w-5 h-5" /> : <ToggleLeft className="w-5 h-5" />}
@@ -506,9 +498,8 @@ function SlotList({ title, slots, products, images, stockEdits, setStockEdits, o
 
 const HERO_IMAGE_FALLBACK = "/products/product-1779659787800.jpeg";
 
-function SlotImageTrigger({ slot, images, onSave }: {
+function SlotImageTrigger({ slot, onSave }: {
   slot: Slot;
-  images: string[];
   onSave: (imageUrl: string, focalX: number, focalY: number, imageScale: number) => void;
 }) {
   const [showModal, setShowModal] = useState(false);

--- a/app/admin/(panel)/pedidos/page.tsx
+++ b/app/admin/(panel)/pedidos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { Loader2, Phone, MapPin, Package, Home, ChevronDown } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
@@ -36,15 +36,15 @@ function PedidosContent() {
   const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState<number | null>(null);
 
-  async function fetchOrders() {
+  const fetchOrders = useCallback(async () => {
     const url = slotFilter ? `/api/admin/orders?slotId=${slotFilter}` : "/api/admin/orders";
     const res = await fetch(url);
     const data = await res.json();
     setOrders(data);
     setLoading(false);
-  }
+  }, [slotFilter]);
 
-  useEffect(() => { fetchOrders(); }, [slotFilter]);
+  useEffect(() => { fetchOrders(); }, [fetchOrders]);
 
   async function updateStatus(orderId: number, status: string) {
     setUpdating(orderId);

--- a/app/admin/(panel)/productos/page.tsx
+++ b/app/admin/(panel)/productos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Plus, Pencil, Trash2, Loader2, X, Check, ToggleLeft, ToggleRight, ImagePlus } from "lucide-react";
 import Image from "next/image";
 import ImageZoomModal from "@/components/ImageZoomModal";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -117,13 +117,6 @@ export default function Home() {
     setCart({});
   }
 
-  function goHome() {
-    setView("home");
-    setSelectedSlotId(null);
-    setCart({});
-    localStorage.removeItem("brot74-cart");
-  }
-
   function addToCart(productId: number) {
     setCart((prev) => ({ ...prev, [productId]: (prev[productId] ?? 0) + 1 }));
   }

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -212,7 +212,7 @@ function NoSlotsEmptyState() {
   );
 }
 
-export default function DateSelector({ slots, selectedId, onChange }: DateSelectorProps) {
+export default function DateSelector({ slots, onChange }: DateSelectorProps) {
   const visibleSlots = slots.filter((s) => !s.disabled);
 
   if (visibleSlots.length === 0) {

--- a/components/ImageZoomModal.tsx
+++ b/components/ImageZoomModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import Image from "next/image";
 import { X, ZoomIn, ZoomOut } from "lucide-react";
 
 interface ImageZoomModalProps {

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { formatCurrency } from "@/lib/utils";
 
 interface ProductCardProps {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,16 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      // Flags any setState call reachable in an effect body, including the
+      // standard "fetch on mount/dep change" and "restore from localStorage"
+      // patterns used across the admin panels and the storefront cart. Kept
+      // as a warning instead of an error to avoid forcing a risky rewrite of
+      // that state logic just to satisfy the linter.
+      "react-hooks/set-state-in-effect": "warn",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:


### PR DESCRIPTION
## Resumen
Reintento de [#9](https://github.com/gastton/brot74-web/pull/9) (cerrado por quedar desactualizado contra ~20 commits que se pushearon a `main` mientras tanto). Mismo criterio, reaplicado sobre el código de hoy:

- Job `lint` nuevo en `.github/workflows/test.yml`, corre en paralelo a `integration`.
- Se limpiaron los warnings preexistentes de código muerto (imports/vars sin usar, deps de `useEffect`) para poder bloquear en error sin ruido.
- `react-hooks/set-state-in-effect` se bajó a `warning`: regla nueva del set de "React Compiler" que marca cualquier `setState` síncrono dentro de un efecto, incluyendo patrones legítimos ya en uso (fetch de productos/pedidos al montar, restauración de carrito desde localStorage). Documentado con comentario en `eslint.config.mjs`.
- De nuevo apareció plumbing muerta en el panel de fechas (estado `images`, fetch a `/api/admin/images`, prop threading por `SlotList`/`SlotImageTrigger`) — limpiada otra vez. El endpoint sigue trackeado en [BRT-81](https://brot74.atlassian.net/browse/BRT-81).

## Test plan
- [x] `npm run lint` — 0 errores, 5 warnings esperados (los de `set-state-in-effect` bajados a warning).
- [x] `npx tsc --noEmit` — sin errores.
- [x] `npx vitest run` (suite completa) — 86/86 pasan.

[BRT-81]: https://brot74.atlassian.net/browse/BRT-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ