### PR TITLE
fix: vaciar el carrito cuando expira la reserva del pedido (BRT-87)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -183,7 +183,7 @@ export default function Home() {
     }
   }
 
-  function handleModalClose() {
+  function handleModalClose(reason?: "expired") {
     if (sessionToken) {
       fetch("/api/cart/release", {
         method: "POST",
@@ -194,6 +194,12 @@ export default function Home() {
     setShowModal(false);
     setSessionToken("");
     setReservationExpiresAt("");
+    if (reason === "expired") {
+      // La reserva venció: no dejamos el carrito con productos "elegidos"
+      // sobre una reserva que ya no existe — se vuelve a armar de cero.
+      setCart({});
+      localStorage.removeItem("brot74-cart");
+    }
     if (selectedSlotId) fetchProducts(selectedSlotId);
   }
 

--- a/components/OrderModal.tsx
+++ b/components/OrderModal.tsx
@@ -20,7 +20,7 @@ interface OrderModalProps {
   expiresAt: string;
   onRemoveItem: (productId: number) => void;
   onChangeQuantity: (productId: number, newQuantity: number) => void;
-  onClose: () => void;
+  onClose: (reason?: "expired") => void;
   onSuccess: (orderId: number) => void;
 }
 
@@ -106,7 +106,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
         setExpired(true);
         // En el form cerramos solo: en pago dejamos el mensaje fijo hasta
         // que el usuario elija cerrar (ver panel "Tu pedido expiró").
-        if (step === "form") setTimeout(onClose, 4000);
+        if (step === "form") setTimeout(() => onClose("expired"), 4000);
       }
     }, 1000);
 
@@ -222,7 +222,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
       <div
         className="absolute inset-0"
         style={{ background: "rgba(14,35,60,.58)", backdropFilter: "blur(3px)", WebkitBackdropFilter: "blur(3px)" }}
-        onClick={onClose}
+        onClick={() => onClose()}
       />
 
       {/* Modal */}
@@ -360,7 +360,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
                   </div>
                   <button
                     type="button"
-                    onClick={onClose}
+                    onClick={() => onClose("expired")}
                     className="w-full font-bold text-[16.5px] tracking-[.01em]"
                     style={{
                       marginTop: "16px",
@@ -509,7 +509,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
               </p>
               <button
                 type="button"
-                onClick={onClose}
+                onClick={() => onClose()}
                 className="btn-primary mb-3"
                 style={{ maxWidth: "300px" }}
               >
@@ -518,7 +518,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
               </button>
               <button
                 type="button"
-                onClick={onClose}
+                onClick={() => onClose()}
                 className="w-full font-semibold text-[15px] text-stone border-none bg-transparent cursor-pointer py-2"
                 style={{ maxWidth: "300px" }}
               >
@@ -625,7 +625,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
             <div className="brot-co-actions" style={{ display: "flex", alignItems: "stretch", gap: "8px", marginTop: "20px" }}>
               <button
                 type="button"
-                onClick={onClose}
+                onClick={() => onClose()}
                 className="flex-1 min-w-0 font-bold text-[14px] tracking-[.01em] whitespace-nowrap overflow-hidden text-ellipsis"
                 style={{
                   border: "1.5px solid rgba(14,35,60,.14)",


### PR DESCRIPTION
## Resumen
Encontrado al validar [BRT-86](https://brot74.atlassian.net/browse/BRT-86) en producción: cuando el modal se cerraba por expiración de la reserva, el carrito (`app/page.tsx` + `localStorage`) seguía mostrando los productos "elegidos" — sin riesgo real (una nueva reserva se valida contra stock actual al reabrir), pero confuso, ya que el mensaje dice "volvé a elegir tus productos".

- `OrderModal`'s `onClose` ahora acepta un motivo opcional: `onClose(reason?: "expired")`.
- Solo se pasa `"expired"` en los dos cierres disparados por la expiración (auto-cierre a los 4s en "Tu pedido", botón "Cerrar y volver a elegir" en "Pagá por transferencia").
- `handleModalClose` en `app/page.tsx` vacía el carrito (`setCart({})` + `localStorage.removeItem`) solo cuando `reason === "expired"`.
- Los cierres voluntarios (X, "Seguir comprando", click en el fondo) siguen preservando el carrito — verificado manualmente que no se rompió ese caso.

Fixes [BRT-87](https://brot74.atlassian.net/browse/BRT-87).

## Test plan
- [x] `npx tsc --noEmit` — sin errores.
- [x] `npx eslint components/OrderModal.tsx app/page.tsx` — 0 errores, 2 warnings preexistentes (`set-state-in-effect`, ya bajados a warning).
- [x] `npx vitest run` (suite completa) — 86/86 pasan.
- [x] Verificación manual en navegador: adelanté el reloj del cliente en "Pagá por transferencia", confirmé que al expirar y tocar "Cerrar y volver a elegir" el carrito queda vacío (sin barra flotante, `localStorage` en `null`). Repetí el flujo cerrando con la "X" antes de expirar y confirmé que el carrito se preserva.

[BRT-86]: https://brot74.atlassian.net/browse/BRT-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-87]: https://brot74.atlassian.net/browse/BRT-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ