### PR TITLE
BRT-90: aplicar v30 — nuevo tono de crema + hero del home a fondo claro

### DIFF
--- a/app/confirmacion/page.tsx
+++ b/app/confirmacion/page.tsx
@@ -55,8 +55,8 @@ function ConfirmacionContent() {
             viewBox="0 0 100 100"
             aria-hidden="true"
           >
-            <circle cx="50" cy="50" r="48" fill="none" stroke="#F4EEE2" strokeWidth="0.7" opacity="0.85" />
-            <circle cx="50" cy="50" r="43.6" fill="none" stroke="#F4EEE2" strokeWidth="0.32" opacity="0.45" />
+            <circle cx="50" cy="50" r="48" fill="none" stroke="#F9F5EC" strokeWidth="0.7" opacity="0.85" />
+            <circle cx="50" cy="50" r="43.6" fill="none" stroke="#F9F5EC" strokeWidth="0.32" opacity="0.45" />
           </svg>
           <div
             style={{
@@ -80,7 +80,7 @@ function ConfirmacionContent() {
                 fontFamily: "var(--font-jost, 'Jost', sans-serif)",
               }}
             >
-              <span style={{ fontWeight: 500, fontSize: ".115em", color: "#F4EEE2" }}>BROT</span>
+              <span style={{ fontWeight: 500, fontSize: ".115em", color: "#F9F5EC" }}>BROT</span>
               <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
             </div>
           </div>
@@ -122,7 +122,7 @@ function ConfirmacionContent() {
           className="mt-6 block w-full font-bold text-[16.5px] tracking-[.01em] py-[17px] rounded-[14px] no-underline flex items-center justify-center"
           style={{
             background: "#0E233C",
-            color: "#F4EEE2",
+            color: "#F9F5EC",
             transition: "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s",
           }}
           onMouseEnter={(e) => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,7 @@
   /* BROT 74 — Paleta de marca */
   --color-navy:     #0E233C;
   --color-amber:    #C8851A;
-  --color-cream:    #F4EEE2;
+  --color-cream:    #F9F5EC;
   --color-paper:    #FBF7EF;
   --color-stone:    #7C766A;
   --color-open:     #16C65A;
@@ -25,7 +25,7 @@
 }
 
 :root {
-  --background: #F4EEE2;
+  --background: #F9F5EC;
   --foreground: #0E233C;
 }
 
@@ -59,7 +59,7 @@ body {
 /* ── Botón principal ── */
 .btn-primary {
   background-color: #0E233C;
-  color: #F4EEE2;
+  color: #F9F5EC;
   padding: 17px 24px;
   border-radius: 14px;
   font-family: var(--font-hanken, 'Hanken Grotesk'), system-ui, sans-serif;
@@ -109,13 +109,14 @@ textarea.brot-input {
   line-height: 1.5;
 }
 
-/* ── Hero v13 — kicker con filetes laterales ── */
+/* ── Hero v13 — kicker con filetes laterales (v30: color más oscuro,
+   legible sobre el fondo crema del hero) ── */
 .brot-hero-kicker {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 16px;
-  color: #E0A33A;
+  color: #C8851A;
   font-weight: 600;
   font-size: 13px;
   letter-spacing: .34em;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -217,7 +217,7 @@ export default function Home() {
   /* ─── SLOTS VIEW ────────────────────────────────────────── */
   if (view === "slots") {
     return (
-      <div className="min-h-screen" style={{ background: "#F4EEE2" }}>
+      <div className="min-h-screen" style={{ background: "#F9F5EC" }}>
         <main className="w-full max-w-[430px] min-[900px]:max-w-[780px] mx-auto px-6 py-10">
           {/* Título */}
           <header className="mb-5 text-center">
@@ -356,18 +356,18 @@ export default function Home() {
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
 
-        {/* ── Hero (banda navy) ── */}
+        {/* ── Hero (v30: banda crema, antes navy) ── */}
         <section
           className="brot-hero-section flex flex-col items-center text-center"
           style={{
-            background: "radial-gradient(120% 60% at 50% 22%, rgba(200,133,26,.10), rgba(14,35,60,0) 60%), #0E233C",
+            background: "radial-gradient(120% 60% at 50% 22%, rgba(200,133,26,.10), rgba(14,35,60,0) 60%), #F9F5EC",
             minHeight: "100svh",
             padding: "64px 40px 40px",
             position: "relative",
             justifyContent: "center",
           }}
         >
-          {/* Sello invertido — ramillete crema sobre navy */}
+          {/* Sello — v30: ramillete navy sobre crema (antes crema sobre navy) */}
           <div
             className="brot-hero-seal-wrap"
             style={{
@@ -384,8 +384,8 @@ export default function Home() {
               viewBox="0 0 100 100"
               aria-hidden="true"
             >
-              <circle cx="50" cy="50" r="48" fill="none" stroke="#F4EEE2" strokeWidth="0.7" opacity="0.85" />
-              <circle cx="50" cy="50" r="43.6" fill="none" stroke="#F4EEE2" strokeWidth="0.32" opacity="0.45" />
+              <circle cx="50" cy="50" r="48" fill="none" stroke="#0E233C" strokeWidth="0.7" opacity="0.85" />
+              <circle cx="50" cy="50" r="43.6" fill="none" stroke="#0E233C" strokeWidth="0.32" opacity="0.45" />
             </svg>
             <div
               style={{
@@ -399,7 +399,7 @@ export default function Home() {
               }}
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/ramillete-mono-cream.png" alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
+              <img src="/ramillete-mono-navy.png" alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
               <div
                 style={{
                   display: "inline-flex",
@@ -409,7 +409,7 @@ export default function Home() {
                   fontFamily: "var(--font-jost, 'Jost', sans-serif)",
                 }}
               >
-                <span style={{ fontWeight: 500, fontSize: ".115em", color: "#F4EEE2" }}>BROT</span>
+                <span style={{ fontWeight: 500, fontSize: ".115em", color: "#0E233C" }}>BROT</span>
                 <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
               </div>
             </div>
@@ -429,7 +429,7 @@ export default function Home() {
               fontSize: "clamp(40px, 7.5vw, 60px)",
               lineHeight: 1.08,
               letterSpacing: "-.015em",
-              color: "#F4EEE2",
+              color: "#0E233C",
               margin: "26px 0 0",
               maxWidth: "13ch",
               textWrap: "balance" as React.CSSProperties["textWrap"],
@@ -479,7 +479,7 @@ export default function Home() {
         <footer
           style={{
             background: "#0E233C",
-            borderTop: "1px solid rgba(244,238,226,.08)",
+            borderTop: "1px solid rgba(249,245,236,.08)",
             padding: "14px 24px",
             display: "flex",
             alignItems: "center",
@@ -493,7 +493,7 @@ export default function Home() {
               fontSize: "10.5px",
               letterSpacing: ".08em",
               textTransform: "uppercase",
-              color: "rgba(244,238,226,.42)",
+              color: "rgba(249,245,236,.42)",
             }}
           >
             Powered by

--- a/components/CartBar.tsx
+++ b/components/CartBar.tsx
@@ -23,7 +23,7 @@ export default function CartBar({ count, total, reserving, error, onCheckout }: 
     <div
       className="fixed bottom-0 left-0 right-0 z-[60] p-4"
       style={{
-        background: "linear-gradient(to top, #F4EEE2 60%, transparent)",
+        background: "linear-gradient(to top, #F9F5EC 60%, transparent)",
         paddingBottom: "calc(16px + env(safe-area-inset-bottom))",
       }}
     >
@@ -41,7 +41,7 @@ export default function CartBar({ count, total, reserving, error, onCheckout }: 
           className="w-full flex items-center gap-3 rounded-[16px] border-none"
           style={{
             background: "#0E233C",
-            color: "#F4EEE2",
+            color: "#F9F5EC",
             padding: "14px 18px",
             cursor: "pointer",
             boxShadow: "0 8px 24px -8px rgba(14,35,60,.5)",
@@ -50,8 +50,8 @@ export default function CartBar({ count, total, reserving, error, onCheckout }: 
           onMouseEnter={(e) => { e.currentTarget.style.transform = "translateY(-2px)"; }}
           onMouseLeave={(e) => { e.currentTarget.style.transform = ""; }}
         >
-          <span className="w-9 h-9 flex-none rounded-full flex items-center justify-center" style={{ border: "1px solid rgba(244,238,226,.38)" }}>
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#F4EEE2" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+          <span className="w-9 h-9 flex-none rounded-full flex items-center justify-center" style={{ border: "1px solid rgba(249,245,236,.38)" }}>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#F9F5EC" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
               <path d="M6 8h12l-1 12H7L6 8Z"/><path d="M9 8V6a3 3 0 0 1 6 0v2"/>
             </svg>
           </span>
@@ -59,7 +59,7 @@ export default function CartBar({ count, total, reserving, error, onCheckout }: 
             {reserving ? "Reservando…" : `${count} producto${count !== 1 ? "s" : ""}`}
           </span>
           <span className="font-bold text-[18px] ml-auto whitespace-nowrap">{formatCurrency(total)}</span>
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#F4EEE2" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#F9F5EC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M9 6l6 6-6 6"/>
           </svg>
         </button>

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -68,7 +68,7 @@ function InfoRow({ icon, label, value, last }: InfoRowProps) {
     >
       <span
         className="flex-none w-[42px] h-[42px] rounded-full flex items-center justify-center"
-        style={{ background: "#F4EEE2", border: "1px solid rgba(14,35,60,.10)" }}
+        style={{ background: "#F9F5EC", border: "1px solid rgba(14,35,60,.10)" }}
       >
         {icon}
       </span>
@@ -144,7 +144,7 @@ function NoSlotsEmptyState() {
 
       {/* Formulario / confirmación */}
       {sent ? (
-        <div className="flex flex-col items-center gap-2 mt-6 rounded-[14px] py-5 px-4" style={{ background: "#F4EEE2" }}>
+        <div className="flex flex-col items-center gap-2 mt-6 rounded-[14px] py-5 px-4" style={{ background: "#F9F5EC" }}>
           <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="#C8851A" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="12" cy="12" r="9"/><path d="M8.5 12.5l2.5 2.5 4.5-5"/>
           </svg>
@@ -176,7 +176,7 @@ function NoSlotsEmptyState() {
             className="w-full border-none cursor-pointer font-bold text-[15px] tracking-[.03em] py-4 rounded-[14px]"
             style={{
               background: "#0E233C",
-              color: "#F4EEE2",
+              color: "#F9F5EC",
               transition: "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s",
               opacity: loading ? 0.6 : 1,
             }}
@@ -280,7 +280,7 @@ export default function DateSelector({ slots, onChange }: DateSelectorProps) {
               {/* Fecha centrada */}
               <div
                 className="absolute inset-0 flex flex-col items-center justify-center text-center select-none"
-                style={{ color: "#F4EEE2", textShadow: "0 2px 18px rgba(14,35,60,.5)" }}
+                style={{ color: "#F9F5EC", textShadow: "0 2px 18px rgba(14,35,60,.5)" }}
               >
                 <div className="font-bold text-[17px] tracking-[.3em] uppercase">{weekday}</div>
                 <div className="font-semibold text-[12px] tracking-[.3em] uppercase mt-0.5" style={{ opacity: 0.85 }}>
@@ -317,7 +317,7 @@ export default function DateSelector({ slots, onChange }: DateSelectorProps) {
                 className="group mt-[18px] w-full flex items-center justify-center gap-[10px] font-bold text-[15px] tracking-[.03em] py-[17px] rounded-[14px] disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{
                   background: "#0E233C",
-                  color: "#F4EEE2",
+                  color: "#F9F5EC",
                   transition: "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s",
                 }}
                 onMouseEnter={(e) => { if (isOpen) { e.currentTarget.style.transform = "translateY(-2px)"; e.currentTarget.style.boxShadow = "0 16px 30px -16px rgba(14,35,60,.55)"; } }}

--- a/components/OrderModal.tsx
+++ b/components/OrderModal.tsx
@@ -43,7 +43,7 @@ function CloseIcon() {
   );
 }
 
-function BagIcon({ stroke = "#F4EEE2" }: { stroke?: string }) {
+function BagIcon({ stroke = "#F9F5EC" }: { stroke?: string }) {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
       <path d="M6 8h12l-1 12H7L6 8Z"/><path d="M9 8V6a3 3 0 0 1 6 0v2"/>
@@ -144,7 +144,7 @@ function ConfirmDialog({
             style={{
               border: "none",
               background: "#0E233C",
-              color: "#F4EEE2",
+              color: "#F9F5EC",
               borderRadius: "14px",
               padding: "13px 6px",
               cursor: "pointer",
@@ -466,7 +466,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
                   marginTop: "22px",
                   border: "none",
                   background: "#0E233C",
-                  color: "#F4EEE2",
+                  color: "#F9F5EC",
                   borderRadius: "14px",
                   padding: "10px",
                   cursor: (loading || !hasCopiedAlias || expired) ? "not-allowed" : "pointer",
@@ -683,7 +683,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
                   cursor: "pointer",
                   transition: "transform .18s cubic-bezier(.2,.7,.3,1), background .15s",
                 }}
-                onMouseEnter={(e) => { e.currentTarget.style.background = "#F4EEE2"; e.currentTarget.style.transform = "translateY(-2px)"; }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = "#F9F5EC"; e.currentTarget.style.transform = "translateY(-2px)"; }}
                 onMouseLeave={(e) => { e.currentTarget.style.background = "#fff"; e.currentTarget.style.transform = ""; }}
               >
                 Seguir comprando
@@ -695,7 +695,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
                 style={{
                   border: "none",
                   background: "#0E233C",
-                  color: "#F4EEE2",
+                  color: "#F9F5EC",
                   borderRadius: "16px",
                   padding: "10px 8px",
                   cursor: expired ? "not-allowed" : "pointer",
@@ -722,7 +722,7 @@ export default function OrderModal({ items, slotId, slotLabel, sessionToken, exp
             top: "28px",
             transform: toastVisible ? "translateX(-50%) translateY(0)" : "translateX(-50%) translateY(-12px)",
             background: "#0E233C",
-            color: "#F4EEE2",
+            color: "#F9F5EC",
             fontWeight: 600,
             fontSize: "14px",
             padding: "11px 20px",

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -90,7 +90,7 @@ export default function ProductCard({
 
         {/* Velo sin stock */}
         {outOfStock && (
-          <div className="absolute inset-0" style={{ background: "rgba(244,238,226,.5)" }} />
+          <div className="absolute inset-0" style={{ background: "rgba(249,245,236,.5)" }} />
         )}
 
         {/* Badge sin stock */}
@@ -113,7 +113,7 @@ export default function ProductCard({
         {quantity > 0 && !outOfStock && (
           <div
             className="absolute top-2 right-2 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
-            style={{ background: "#0E233C", color: "#F4EEE2", boxShadow: "0 2px 8px rgba(14,35,60,.4)" }}
+            style={{ background: "#0E233C", color: "#F9F5EC", boxShadow: "0 2px 8px rgba(14,35,60,.4)" }}
           >
             {quantity}
           </div>
@@ -123,7 +123,7 @@ export default function ProductCard({
         {slotSelected && remaining !== null && remaining <= 2 && remaining > 0 && (
           <div
             className="absolute top-2 left-2 text-xs font-semibold px-2 py-0.5 rounded-full"
-            style={{ background: "#C8851A", color: "#F4EEE2" }}
+            style={{ background: "#C8851A", color: "#F9F5EC" }}
           >
             Últimos {remaining}
           </div>

--- a/components/ProductModal.tsx
+++ b/components/ProductModal.tsx
@@ -254,7 +254,7 @@ export default function ProductModal({
           )}
 
           {!slotSelected && (
-            <p className="mt-4 text-[13px] font-medium text-stone bg-[#F4EEE2] rounded-xl px-4 py-3">
+            <p className="mt-4 text-[13px] font-medium text-stone bg-[#F9F5EC] rounded-xl px-4 py-3">
               Elegí una fecha de entrega para agregar al pedido
             </p>
           )}
@@ -302,7 +302,7 @@ export default function ProductModal({
                   className="brot-modal-cta w-full font-bold text-[15.5px] tracking-[.01em] py-4 rounded-[14px] border-none"
                   style={{
                     background: "#0E233C",
-                    color: "#F4EEE2",
+                    color: "#F9F5EC",
                     opacity: canAdd ? 1 : 0.4,
                     cursor: canAdd ? "pointer" : "not-allowed",
                     transition: ctaTransition,
@@ -319,7 +319,7 @@ export default function ProductModal({
                   <div
                     className="inline-flex items-center gap-1"
                     style={{
-                      background: "#F4EEE2",
+                      background: "#F9F5EC",
                       border: "1.5px solid rgba(14,35,60,.16)",
                       borderRadius: "14px",
                       padding: "5px",
@@ -358,7 +358,7 @@ export default function ProductModal({
                         width: "44px",
                         height: "44px",
                         background: "#0E233C",
-                        color: "#F4EEE2",
+                        color: "#F9F5EC",
                         cursor: canAdd ? "pointer" : "not-allowed",
                         opacity: canAdd ? 1 : 0.35,
                         transition: "transform .12s, opacity .15s",
@@ -392,7 +392,7 @@ export default function ProductModal({
             <div className="brot-modal-controls-mobile flex-col gap-[14px]">
               <div
                 className="w-full flex items-center justify-between"
-                style={{ background: "#F4EEE2", border: "1.5px solid rgba(14,35,60,.16)", borderRadius: "14px", padding: "5px" }}
+                style={{ background: "#F9F5EC", border: "1.5px solid rgba(14,35,60,.16)", borderRadius: "14px", padding: "5px" }}
               >
                 <button
                   type="button"
@@ -428,7 +428,7 @@ export default function ProductModal({
                     width: "44px",
                     height: "44px",
                     background: "#0E233C",
-                    color: "#F4EEE2",
+                    color: "#F9F5EC",
                     cursor: (mobileOutOfStock || mobileMaxReached) ? "not-allowed" : "pointer",
                     opacity: (mobileOutOfStock || mobileMaxReached) ? 0.35 : 1,
                     transition: "transform .12s, opacity .15s",
@@ -448,7 +448,7 @@ export default function ProductModal({
                 className="w-full font-bold text-[15.5px] tracking-[.01em] py-4 rounded-[14px] border-none"
                 style={{
                   background: "#0E233C",
-                  color: "#F4EEE2",
+                  color: "#F9F5EC",
                   opacity: mobileCanConfirm ? 1 : 0.4,
                   cursor: mobileCanConfirm ? "pointer" : "not-allowed",
                   transition: ctaTransition,
@@ -473,7 +473,7 @@ export default function ProductModal({
               className="brot-modal-desktop-bar flex items-center gap-3 w-full mt-5 rounded-[16px] border-none"
               style={{
                 background: "#0E233C",
-                color: "#F4EEE2",
+                color: "#F9F5EC",
                 padding: "14px 18px",
                 cursor: "pointer",
                 transition: ctaTransition,
@@ -483,9 +483,9 @@ export default function ProductModal({
             >
               <span
                 className="w-9 h-9 flex-none rounded-full flex items-center justify-center"
-                style={{ border: "1px solid rgba(244,238,226,.38)" }}
+                style={{ border: "1px solid rgba(249,245,236,.38)" }}
               >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#F4EEE2" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#F9F5EC" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M6 8h12l-1 12H7L6 8Z"/><path d="M9 8V6a3 3 0 0 1 6 0v2"/>
                 </svg>
               </span>
@@ -495,7 +495,7 @@ export default function ProductModal({
               <span className="font-bold text-[18px] ml-auto whitespace-nowrap">
                 {formatCurrency(cartTotal)}
               </span>
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#F4EEE2" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 6l6 6-6 6"/></svg>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#F9F5EC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 6l6 6-6 6"/></svg>
             </button>
           )}
         </div>


### PR DESCRIPTION
## Resumen

Aplica la entrega de diseño v30 (`_design/design_cambios_v30/`). Jira: [BRT-90](https://brot74.atlassian.net/browse/BRT-90).

## Cambios

1. Retinte `#F4EEE2` → `#F9F5EC` (+ rgba equivalente) en toda la web de cliente.
2. Hero del home: fondo navy → crema, con el aro del sello, wordmark, ramillete, título y kicker ajustados para mantener contraste. Footer sigue navy.

Fuera de alcance: `app/admin/**` (no está en los mockups de la entrega), y el sello de `confirmacion/page.tsx` (mantiene su propio disco navy, solo recibe el retinte).

## Verificación

- `eslint` y `tsc --noEmit` sin errores nuevos.
- Verificado visualmente en preview: home, listado de productos (retinte + funcionalidad de BRT-89 intacta), confirmación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-90]: https://brot74.atlassian.net/browse/BRT-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ