### PR TITLE
Hero: sello más grande y con más presencia

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -154,14 +154,14 @@ textarea.brot-input {
 /* ── Hero fix: compresión vertical en pantallas bajas (v17) ── */
 @media (max-height: 760px) {
   .brot-hero-section { padding: 40px 40px 28px !important; }
-  .brot-hero-seal-wrap { width: 148px !important; height: 148px !important; font-size: 148px !important; }
+  .brot-hero-seal-wrap { width: 182px !important; height: 182px !important; font-size: 182px !important; }
   .brot-hero-kicker { margin-top: 30px !important; }
   .brot-hero-h1 { margin-top: 20px !important; font-size: clamp(32px, 7vw, 46px) !important; }
   .brot-hero-cta { margin-top: 30px !important; }
   .brot-hero-foot { bottom: 20px !important; }
 }
 @media (max-height: 640px) {
-  .brot-hero-seal-wrap { width: 124px !important; height: 124px !important; font-size: 124px !important; }
+  .brot-hero-seal-wrap { width: 152px !important; height: 152px !important; font-size: 152px !important; }
   .brot-hero-kicker { margin-top: 22px !important; }
   .brot-hero-h1 { margin-top: 16px !important; font-size: clamp(29px, 6.6vw, 40px) !important; }
   .brot-hero-cta { margin-top: 24px !important; padding: 15px 26px !important; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -388,9 +388,9 @@ export default function Home() {
             className="brot-hero-seal-wrap"
             style={{
               position: "relative",
-              width: "188px",
-              height: "188px",
-              fontSize: "188px",
+              width: "230px",
+              height: "230px",
+              fontSize: "230px",
               flexShrink: 0,
               filter: "drop-shadow(0 20px 36px rgba(0,0,0,.35))",
             }}
@@ -400,8 +400,8 @@ export default function Home() {
               viewBox="0 0 100 100"
               aria-hidden="true"
             >
-              <circle cx="50" cy="50" r="48" fill="none" stroke="#0E233C" strokeWidth="0.7" opacity="0.85" />
-              <circle cx="50" cy="50" r="43.6" fill="none" stroke="#0E233C" strokeWidth="0.32" opacity="0.45" />
+              <circle cx="50" cy="50" r="48" fill="none" stroke="#0E233C" strokeWidth="1" opacity="0.95" />
+              <circle cx="50" cy="50" r="43.6" fill="none" stroke="#0E233C" strokeWidth="0.5" opacity="0.6" />
             </svg>
             <div
               style={{


### PR DESCRIPTION
Cambio cosmético de dos archivos (proceso liviano, sin ticket de Jira).

El sello (aro + ramillete + wordmark) del hero se veía chico/débil comparado con el título y el CTA en el nuevo fondo crema (v30). Sube el tamaño base 188px → 230px (las dos variantes de pantalla baja escalan proporcionalmente), y el trazo del aro pasa a más grueso/opaco para que no se lea tan fino sobre fondo claro.

No toca el sello de `confirmacion/page.tsx` (es un disco propio con fondo navy, no el hero, no fue parte del reporte).

`eslint` y `tsc --noEmit` sin errores. Verificado en preview (pantalla normal y forzando poca altura).

🤖 Generated with [Claude Code](https://claude.com/claude-code)