### PR TITLE
Foto más alta en la fila de producto mobile

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -59,7 +59,7 @@ export default function ProductCard({
       {/* Foto — mobile: miniatura fija a la derecha (BRT-92). Desktop: sin
          cambios, cuadrada a todo el ancho de la card. */}
       <div
-        className="relative overflow-hidden flex-none w-[104px] h-[104px] md:w-full md:h-auto md:aspect-square"
+        className="relative overflow-hidden flex-none w-[104px] h-[200px] md:w-full md:h-auto md:aspect-square"
         style={{
           borderRadius: "16px",
           background: "#ddd6c8",


### PR DESCRIPTION
Cambio cosmético de un archivo (proceso liviano, sin ticket). El botón "+" tapaba buena parte de la foto miniatura (104x104). Sube el alto a 200px, el ancho y el desktop no cambian.

`eslint` y `tsc --noEmit` sin errores. Verificado en preview mobile y desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)