### PR TITLE
BRT-93: ver foto del producto a pantalla completa (lupa)

### DIFF
--- a/components/ImageZoomModal.tsx
+++ b/components/ImageZoomModal.tsx
@@ -69,15 +69,21 @@ export default function ImageZoomModal({ src, alt = "", onClose }: ImageZoomModa
         </button>
       </div>
 
-      {/* Image */}
+      {/* Image — click en el fondo (fuera de la imagen) cierra el modal
+         (BRT-93); click en la imagen misma sigue alternando el zoom, sin
+         cambios. stopPropagation en la imagen para que no dispare las dos
+         cosas a la vez. */}
       <div
         ref={containerRef}
         className="flex-1 overflow-hidden flex items-center justify-center cursor-zoom-in"
         onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
-        onClick={() => setScale(s => s > MIN ? MIN : 2)}
+        onClick={onClose}
       >
-        <div style={{ transform: `scale(${scale})`, transition: "transform 0.1s ease", transformOrigin: "center" }}>
+        <div
+          style={{ transform: `scale(${scale})`, transition: "transform 0.1s ease", transformOrigin: "center" }}
+          onClick={(e) => { e.stopPropagation(); setScale(s => s > MIN ? MIN : 2); }}
+        >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={src} alt={alt} className="max-w-[90vw] max-h-[80vh] object-contain rounded-lg" />
         </div>

--- a/components/ProductModal.tsx
+++ b/components/ProductModal.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { ShoppingCart } from "lucide-react";
+import { ShoppingCart, Search } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
+import ImageZoomModal from "./ImageZoomModal";
 
 interface Product {
   id: number;
@@ -58,6 +59,7 @@ export default function ProductModal({
   onCheckout,
 }: ProductModalProps) {
   const [descCollapsed, setDescCollapsed] = useState(true);
+  const [showZoom, setShowZoom] = useState(false); // BRT-93
 
   // Cantidad elegida en mobile (BRT-89): se define ANTES de confirmar, no
   // después — arranca en lo que ya haya en el carrito (o 1 si es la primera
@@ -108,6 +110,7 @@ export default function ProductModal({
     : null;
 
   return (
+    <>
     <div className="brot-modal-backdrop fixed inset-0 z-50 flex justify-center">
       {/* Backdrop */}
       <div
@@ -172,9 +175,14 @@ export default function ProductModal({
           </svg>
         </button>
 
-        {/* Foto */}
+        {/* Foto — click en cualquier parte abre la imagen a pantalla
+           completa (BRT-93), con una lupa en la esquina como pista visual */}
         {product.imageUrl && (
-          <div className="brot-modal-photo relative w-full overflow-hidden" style={{ height: "234px" }}>
+          <div
+            className="brot-modal-photo relative w-full overflow-hidden"
+            style={{ height: "234px", cursor: "pointer" }}
+            onClick={() => setShowZoom(true)}
+          >
             <Image
               src={product.imageUrl}
               alt={product.name}
@@ -183,6 +191,17 @@ export default function ProductModal({
               style={{ objectPosition: `${product.focalX}% ${product.focalY}%` }}
               sizes="(min-width: 900px) 350px, 374px"
             />
+            <span
+              className="absolute bottom-[10px] right-[10px] z-10 w-[34px] h-[34px] rounded-full flex items-center justify-center"
+              style={{
+                background: "rgba(248,243,234,.85)",
+                backdropFilter: "blur(6px)",
+                WebkitBackdropFilter: "blur(6px)",
+                boxShadow: "0 3px 10px -4px rgba(0,0,0,.4)",
+              }}
+            >
+              <Search size={16} color="#0E233C" strokeWidth={2.2} />
+            </span>
           </div>
         )}
 
@@ -500,5 +519,16 @@ export default function ProductModal({
         </div>
       </div>
     </div>
+
+    {/* Zoom de la foto a pantalla completa (BRT-93) — reutiliza el mismo
+       componente que ya usa el admin, sin cambiarle su función de zoom. */}
+    {showZoom && product.imageUrl && (
+      <ImageZoomModal
+        src={product.imageUrl}
+        alt={product.name}
+        onClose={() => setShowZoom(false)}
+      />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Resumen

Jira: [BRT-93](https://brot74.atlassian.net/browse/BRT-93)

## Cambios

- `ProductModal`: la foto es clickeable (lupa como pista visual en la esquina) y abre `ImageZoomModal` mostrando solo la imagen ampliada, sin otros datos del producto. Aplica a mobile y desktop (el ticket no restringía a un breakpoint).
- `ImageZoomModal` (componente compartido, también usado en el admin): se agregó cierre al tocar el fondo, sin tocar su función de zoom in/out existente sobre la imagen (separado con `stopPropagation` para que no disparen las dos cosas a la vez).

## Verificación

- `eslint` y `tsc --noEmit` sin errores.
- Preview mobile y desktop: lupa visible, abre el zoom, cierra con X y con click en el fondo, zoom in/out de la imagen intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-93]: https://brot74.atlassian.net/browse/BRT-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ