### PR TITLE
fix(BRT-96): el "-" del stepper mobile elimina el ítem en cantidad 1

### DIFF
--- a/components/ProductModal.tsx
+++ b/components/ProductModal.tsx
@@ -416,8 +416,20 @@ export default function ProductModal({
               >
                 <button
                   type="button"
-                  onClick={() => setMobileQty((q) => Math.max(1, q - 1))}
-                  disabled={mobileQty <= 1}
+                  onClick={() => {
+                    // BRT-96: en cantidad 1, "−" ya no se limita a clampear el
+                    // stepper local — si el producto YA está en el carrito
+                    // (quantity > 0), lo saca del carrito de una, igual que
+                    // hace el "−" de desktop con onRemove. Si nunca se agregó
+                    // (quantity === 0, mobileQty arranca en 1 igual) no hay
+                    // nada que sacar, así que ahí el botón sigue deshabilitado.
+                    if (mobileQty <= 1) {
+                      if (quantity > 0) { onRemove(); onClose(); }
+                      return;
+                    }
+                    setMobileQty((q) => q - 1);
+                  }}
+                  disabled={mobileQty <= 1 && quantity === 0}
                   aria-label="Restar cantidad"
                   className="flex items-center justify-center rounded-full border-none"
                   style={{
@@ -425,11 +437,11 @@ export default function ProductModal({
                     height: "44px",
                     background: "#FBF7EF",
                     color: "#0E233C",
-                    cursor: mobileQty <= 1 ? "not-allowed" : "pointer",
-                    opacity: mobileQty <= 1 ? 0.4 : 1,
+                    cursor: mobileQty <= 1 && quantity === 0 ? "not-allowed" : "pointer",
+                    opacity: mobileQty <= 1 && quantity === 0 ? 0.4 : 1,
                     transition: "transform .12s, opacity .15s",
                   }}
-                  onMouseDown={(e) => { if (mobileQty > 1) e.currentTarget.style.transform = "scale(.9)"; }}
+                  onMouseDown={(e) => { if (mobileQty > 1 || quantity > 0) e.currentTarget.style.transform = "scale(.9)"; }}
                   onMouseUp={(e) => { e.currentTarget.style.transform = ""; }}
                   onMouseLeave={(e) => { e.currentTarget.style.transform = ""; }}
                 >

--- a/components/ProductModal.tsx
+++ b/components/ProductModal.tsx
@@ -417,21 +417,19 @@ export default function ProductModal({
                 <button
                   type="button"
                   onClick={() => {
-                    // BRT-96: "−" en cantidad 1 siempre te saca del modal —
-                    // nunca queda como un botón inerte/disabled. Si el
-                    // producto ya estaba en el carrito (quantity > 0) lo saca
-                    // a él también, igual que el "−" de desktop con onRemove.
-                    // Si nunca se había agregado, el "1" que se ve acá es
-                    // solo el punto de partida para elegir cantidad, no una
-                    // confirmación — no hay nada que sacar, así que solo
-                    // cierra (mismo efecto que tocar la X).
+                    // BRT-96: en cantidad 1, "−" ya no se limita a clampear el
+                    // stepper local — si el producto YA está en el carrito
+                    // (quantity > 0), lo saca del carrito de una, igual que
+                    // hace el "−" de desktop con onRemove. Si nunca se agregó
+                    // (quantity === 0, mobileQty arranca en 1 igual) no hay
+                    // nada que sacar, así que ahí el botón sigue deshabilitado.
                     if (mobileQty <= 1) {
-                      if (quantity > 0) onRemove();
-                      onClose();
+                      if (quantity > 0) { onRemove(); onClose(); }
                       return;
                     }
                     setMobileQty((q) => q - 1);
                   }}
+                  disabled={mobileQty <= 1 && quantity === 0}
                   aria-label="Restar cantidad"
                   className="flex items-center justify-center rounded-full border-none"
                   style={{
@@ -439,10 +437,11 @@ export default function ProductModal({
                     height: "44px",
                     background: "#FBF7EF",
                     color: "#0E233C",
-                    cursor: "pointer",
+                    cursor: mobileQty <= 1 && quantity === 0 ? "not-allowed" : "pointer",
+                    opacity: mobileQty <= 1 && quantity === 0 ? 0.4 : 1,
                     transition: "transform .12s, opacity .15s",
                   }}
-                  onMouseDown={(e) => { e.currentTarget.style.transform = "scale(.9)"; }}
+                  onMouseDown={(e) => { if (mobileQty > 1 || quantity > 0) e.currentTarget.style.transform = "scale(.9)"; }}
                   onMouseUp={(e) => { e.currentTarget.style.transform = ""; }}
                   onMouseLeave={(e) => { e.currentTarget.style.transform = ""; }}
                 >

--- a/components/ProductModal.tsx
+++ b/components/ProductModal.tsx
@@ -417,19 +417,21 @@ export default function ProductModal({
                 <button
                   type="button"
                   onClick={() => {
-                    // BRT-96: en cantidad 1, "−" ya no se limita a clampear el
-                    // stepper local — si el producto YA está en el carrito
-                    // (quantity > 0), lo saca del carrito de una, igual que
-                    // hace el "−" de desktop con onRemove. Si nunca se agregó
-                    // (quantity === 0, mobileQty arranca en 1 igual) no hay
-                    // nada que sacar, así que ahí el botón sigue deshabilitado.
+                    // BRT-96: "−" en cantidad 1 siempre te saca del modal —
+                    // nunca queda como un botón inerte/disabled. Si el
+                    // producto ya estaba en el carrito (quantity > 0) lo saca
+                    // a él también, igual que el "−" de desktop con onRemove.
+                    // Si nunca se había agregado, el "1" que se ve acá es
+                    // solo el punto de partida para elegir cantidad, no una
+                    // confirmación — no hay nada que sacar, así que solo
+                    // cierra (mismo efecto que tocar la X).
                     if (mobileQty <= 1) {
-                      if (quantity > 0) { onRemove(); onClose(); }
+                      if (quantity > 0) onRemove();
+                      onClose();
                       return;
                     }
                     setMobileQty((q) => q - 1);
                   }}
-                  disabled={mobileQty <= 1 && quantity === 0}
                   aria-label="Restar cantidad"
                   className="flex items-center justify-center rounded-full border-none"
                   style={{
@@ -437,11 +439,10 @@ export default function ProductModal({
                     height: "44px",
                     background: "#FBF7EF",
                     color: "#0E233C",
-                    cursor: mobileQty <= 1 && quantity === 0 ? "not-allowed" : "pointer",
-                    opacity: mobileQty <= 1 && quantity === 0 ? 0.4 : 1,
+                    cursor: "pointer",
                     transition: "transform .12s, opacity .15s",
                   }}
-                  onMouseDown={(e) => { if (mobileQty > 1 || quantity > 0) e.currentTarget.style.transform = "scale(.9)"; }}
+                  onMouseDown={(e) => { e.currentTarget.style.transform = "scale(.9)"; }}
                   onMouseUp={(e) => { e.currentTarget.style.transform = ""; }}
                   onMouseLeave={(e) => { e.currentTarget.style.transform = ""; }}
                 >


### PR DESCRIPTION
## Bug

[BRT-96](https://brot74.atlassian.net/browse/BRT-96): en mobile, el botón "−" del modal de producto quedaba deshabilitado en cantidad 1 y nunca sacaba el producto del carrito — a diferencia de desktop, donde el mismo botón en cantidad 1 sí lo elimina.

## Causa

`components/ProductModal.tsx` tiene dos steppers distintos (BRT-89): el de desktop llama directo a `onRemove` (conectado a `removeFromCart`, que borra el ítem del carrito en cantidad 1); el de mobile solo decrementaba un estado local `mobileQty` clampeado en `Math.max(1, q-1)`, sin tocar nunca el carrito real.

## Fix

Si el producto ya está en el carrito (`quantity > 0`) y se toca "−" en cantidad 1, ahora se llama a `onRemove()` (el mismo callback que usa desktop) y se cierra el modal — igual comportamiento que desktop. Si el producto nunca se agregó (`quantity === 0`), el botón sigue deshabilitado en 1 (no hay nada que sacar).

Los decrementos intermedios (de una cantidad mayor a 1) siguen siendo puramente locales — no tocan el carrito real hasta confirmar con "Sumar N", sin cambios ahí.

## Verificado localmente (viewport mobile 375×812)

- Producto en cantidad 1 en el carrito → "−" habilitado → tap saca el producto, carrito queda vacío (`localStorage` limpio), modal se cierra
- Producto nunca agregado → "−" en cantidad 1 sigue deshabilitado
- Sumar a 3, restar a 1 sin confirmar → el carrito real no se toca en ningún paso intermedio
- Confirmar con "Sumar N" sigue agregando la cantidad correcta al carrito, sin cambios
- `npm run build` y `npm run lint` sin errores (mismos warnings preexistentes del repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-96]: https://brot74.atlassian.net/browse/BRT-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ