### PR TITLE
chore(BRT-99): auditoría de seguridad pre-publicación (Fase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,18 @@ next-env.d.ts
 # SQLite database
 *.db
 *.db-journal
+
+# local Claude Code skills (installed via `npx skills`, kept machine-local)
+/.agents/skills
+/.claude/skills
+/skills-lock.json
+
+# local Claude Code settings (may contain sensitive commands/history, machine-local)
+/.claude/settings.local.json
+
+# design exports and raw screenshots (not source, kept out of the repo)
+/_design/
+/agent/
+/billeteras/
+/footer/
+/pantallas_brot74.pdf


### PR DESCRIPTION
## Ticket
[BRT-99](https://brot74.atlassian.net/browse/BRT-99)

## Resumen de la auditoría

1. **Historial de git por secretos**: escaneado completo (161 commits). No se encontraron API keys, tokens de AWS/GitHub/Slack/Vercel Blob, ni hosts reales de Neon en ningún commit. Las únicas coincidencias de `DATABASE_URL` son las credenciales dummy de test (`brot74:brot74@localhost`), seguras de exponer.
2. **`.claude/` — ⚠️ hallazgo**: nunca se commiteó, pero no estaba protegido por `.gitignore`. `.claude/settings.local.json` contiene comandos `curl` con la contraseña del admin panel en texto plano (de pruebas de sesiones anteriores). **Fix aplicado**: se agrega al `.gitignore`. Recomendación aparte: rotar esa contraseña ya que estuvo en texto plano en disco (nunca llegó a git).
3. **`.env*`**: solo `.env.test.example` fue trackeado alguna vez, y solo contiene credenciales dummy de test. `.env`/`.env.local` nunca se trackearon.
4. **Assets sueltos** (`_design/`, `agent/`, `billeteras/`, `footer/`, `pantallas_brot74.pdf`): son exports de diseño y capturas, no código. Se agregan al `.gitignore` para que no terminen en un repo público.
5. **PII en tests/seeds**: `prisma/seed.ts` solo tiene nombres de productos. `tests/integration/waitlist.test.ts` usa números de teléfono de prueba, no reales.
6. **README**: sigue siendo el boilerplate default de `create-next-app`. No es un riesgo de seguridad, pero si el objetivo es un repo público de portfolio conviene reescribirlo (fuera de alcance de este PR).

## Cambios en este PR
- `.gitignore`: ignora `.claude/settings.local.json` y las carpetas/archivo de assets de diseño.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-99]: https://brot74.atlassian.net/browse/BRT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ