### PR TITLE
fix(BRT-106): eliminar fallbacks hardcodeados de ADMIN_PASSWORD y JWT_SECRET

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,1 +1,3 @@
 DATABASE_URL="postgresql://brot74:brot74@localhost:5433/brot74_test"
+ADMIN_PASSWORD="test-admin-password"
+JWT_SECRET="test-jwt-secret-not-for-production"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
           --health-retries 5
     env:
       DATABASE_URL: postgresql://brot74:brot74@localhost:5432/brot74_test
+      ADMIN_PASSWORD: test-admin-password
+      JWT_SECRET: test-jwt-secret-not-for-production
     steps:
       - uses: actions/checkout@v4
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,21 +2,31 @@ import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
 import { NextRequest } from "next/server";
 
-const secret = new TextEncoder().encode(
-  process.env.JWT_SECRET ?? "brot74-secret-key"
-);
+function requiredEnv(name: "JWT_SECRET" | "ADMIN_PASSWORD"): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Falta la variable de entorno ${name}. No hay un valor por defecto: hay que definirla explícitamente.`
+    );
+  }
+  return value;
+}
+
+function getSecret() {
+  return new TextEncoder().encode(requiredEnv("JWT_SECRET"));
+}
 
 export async function signToken(payload: Record<string, unknown>) {
   return new SignJWT(payload)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime("7d")
-    .sign(secret);
+    .sign(getSecret());
 }
 
 export async function verifyToken(token: string) {
   try {
-    const { payload } = await jwtVerify(token, secret);
+    const { payload } = await jwtVerify(token, getSecret());
     return payload;
   } catch {
     return null;
@@ -37,5 +47,5 @@ export async function requireAdmin(req: NextRequest) {
 }
 
 export function checkAdminPassword(password: string): boolean {
-  return password === (process.env.ADMIN_PASSWORD ?? "brot74admin");
+  return password === requiredEnv("ADMIN_PASSWORD");
 }

--- a/tests/integration/admin-auth.test.ts
+++ b/tests/integration/admin-auth.test.ts
@@ -4,7 +4,7 @@ import { POST as login } from "@/app/api/admin/login/route";
 import { POST as logout } from "@/app/api/admin/logout/route";
 import { verifyToken } from "@/lib/auth";
 
-const CORRECT_PASSWORD = process.env.ADMIN_PASSWORD ?? "brot74admin";
+const CORRECT_PASSWORD = process.env.ADMIN_PASSWORD as string;
 
 function loginRequest(password: string) {
   return new NextRequest("http://localhost/api/admin/login", {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -18,6 +18,14 @@ if (!/localhost|127\.0\.0\.1|postgres:5432/.test(process.env.DATABASE_URL)) {
   );
 }
 
+for (const name of ["ADMIN_PASSWORD", "JWT_SECRET"] as const) {
+  if (!process.env[name]) {
+    throw new Error(
+      `${name} no está definida. Copiá .env.test.example a .env.test (o corré \`npm run test:db:up\`) y completá los valores de test.`
+    );
+  }
+}
+
 import { prisma } from "@/lib/db";
 
 beforeAll(() => {


### PR DESCRIPTION
## Ticket
[BRT-106](https://brot74.atlassian.net/browse/BRT-106)

## Qué cambia
`lib/auth.ts` caía silenciosamente a defaults hardcodeados (`"brot74admin"`, `"brot74-secret-key"`) si `ADMIN_PASSWORD`/`JWT_SECRET` no estaban definidas. Hoy es "seguro" porque el repo es privado, pero esos valores quedarían visibles en el código si el repo se hace público, y un deploy mal configurado degradaría silenciosamente a ellos en vez de fallar.

Ahora `requiredEnv()` tira un error explícito si falta la env var, en lugar de usar un default inseguro.

## Para que no rompa tests/CI
- `tests/setup.ts` valida `ADMIN_PASSWORD`/`JWT_SECRET` igual que ya hacía con `DATABASE_URL`.
- `.env.test.example` documenta los valores dummy de test.
- CI (`integration` job) setea `ADMIN_PASSWORD`/`JWT_SECRET` dummy.
- `admin-auth.test.ts` usa el valor de env en vez de un fallback duplicado.

## Verificación
- `npm test` → 87/87 tests OK, corridos localmente contra Postgres de test.
- `npm run lint` → 0 errores (7 warnings preexistentes en `app/page.tsx`, no relacionados a este cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-106]: https://brot74.atlassian.net/browse/BRT-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ