### PR TITLE
chore(BRT-100): agregar licencia All rights reserved

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2026 Gaston Silva. Todos los derechos reservados.
+
+Este repositorio se publica únicamente con fines de portfolio, para que
+terceros puedan revisar el código como muestra de trabajo.
+
+No se otorga ningún permiso de uso, copia, modificación, distribución,
+sublicencia ni venta de este software o de cualquier parte de él, en forma
+de código fuente o compilada, para ningún propósito, sin autorización
+previa y por escrito del titular de los derechos.
+
+Todos los derechos no otorgados expresamente quedan reservados.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ npm run db:seed
 | `npm run lint` | ESLint |
 | `npm test` | Tests de integración (Vitest) |
 | `npm run db:seed` | Carga datos de ejemplo |
+
+## Licencia
+
+Todos los derechos reservados — ver [LICENSE](LICENSE). El código se publica como muestra de portfolio, no está disponible para reutilización.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "license": "UNLICENSED",
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && prisma db push --accept-data-loss && next build",


### PR DESCRIPTION
## Ticket
[BRT-100](https://brot74.atlassian.net/browse/BRT-100)

## Qué cambia
Decisión tomada: **All rights reserved**. El repo se va a mostrar como portfolio (código visible), pero sin otorgar permiso de reuso/copia/modificación.

- `LICENSE`: aviso de copyright, todos los derechos reservados.
- `package.json`: `"license": "UNLICENSED"` (convención npm equivalente).
- `README.md`: sección "Licencia" con el link.

La segunda parte del ticket (branch protection en `main`) se hace aparte, directo en la config del repo — no es un cambio de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-100]: https://brot74.atlassian.net/browse/BRT-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ