### PR TITLE
chore(BRT-103): dependabot + eslint-plugin-security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,12 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import security from "eslint-plugin-security";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  security.configs.recommended,
   {
     rules: {
       // Flags any setState call reachable in an effect body, including the
@@ -13,6 +15,13 @@ const eslintConfig = defineConfig([
       // as a warning instead of an error to avoid forcing a risky rewrite of
       // that state logic just to satisfy the linter.
       "react-hooks/set-state-in-effect": "warn",
+
+      // Notoriamente ruidosa: marca cualquier acceso a objeto/array con una
+      // key no literal, aunque venga tipada y no de input de usuario (ej.
+      // process.env[name] con `name` como union type). Se deja como warning
+      // para tener la señal disponible sin bloquear el lint por falsos
+      // positivos.
+      "security/detect-object-injection": "warn",
     },
   },
   // Override default ignores of eslint-config-next.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web",
       "version": "0.1.0",
+      "license": "UNLICENSED",
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "@vercel/blob": "^2.4.1",
@@ -33,6 +34,7 @@
         "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.6",
+        "eslint-plugin-security": "^4.0.1",
         "tailwindcss": "^4",
         "tsx": "^4.22.3",
         "typescript": "^5",
@@ -4749,6 +4751,22 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.1.tgz",
+      "integrity": "sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -7184,6 +7202,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -7382,6 +7410,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
+    "eslint-plugin-security": "^4.0.1",
     "tailwindcss": "^4",
     "tsx": "^4.22.3",
     "typescript": "^5",


### PR DESCRIPTION
## Ticket
[BRT-103](https://brot74.atlassian.net/browse/BRT-103)

## Qué cambia
- `.github/dependabot.yml`: alertas de vulnerabilidades + PRs de bump automático semanales (npm + github-actions).
- `eslint-plugin-security` integrado al `eslint.config.mjs` existente. `security/detect-object-injection` queda en `warn` por su conocida tasa de falsos positivos (mismo criterio que ya usaban con `react-hooks/set-state-in-effect` en este archivo) — no rompe el lint (0 errores, warnings nuevos).

## Pendiente (no ejecutable desde acá)
CodeRabbit (punto 15): instalar la GitHub App requiere autorización OAuth desde la cuenta de GitHub del usuario. Instrucciones para hacerlo quedan en el ticket de Jira.

## Verificación
`npm run lint` → 0 errores, exit code 0 (24 warnings: 7 preexistentes + 17 nuevas de `security/detect-object-injection`, todas falsos positivos de accesos tipados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-103]: https://brot74.atlassian.net/browse/BRT-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ