### PR TITLE
chore: soporte para exponer el dev server vía ngrok

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.ngrok-free.app", "*.ngrok-free.dev", "*.ngrok.io"],
   images: {
     remotePatterns: [
       {
@@ -8,6 +9,14 @@ const nextConfig: NextConfig = {
         hostname: "*.public.blob.vercel-storage.com",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [{ key: "ngrok-skip-browser-warning", value: "1" }],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Cambio que ya estaba pendiente en el working directory de una sesión anterior (no relacionado al roadmap de seguridad/code review). Config-only, sin lógica de producción:

- `allowedDevOrigins` para `*.ngrok-free.app/.dev` y `*.ngrok.io`.
- Header `ngrok-skip-browser-warning` para no ver la pantalla de advertencia de ngrok en cada request durante pruebas manuales.

PR de prueba también para confirmar que CodeRabbit está comentando automático tras la instalación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved development access through supported ngrok origins.
  * Suppressed the ngrok browser warning when accessing the application through configured tunnels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->