### PR TITLE
fix(BRT-107): rate limiting en /api/admin/login

### DIFF
--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,12 +1,40 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkAdminPassword, signToken } from "@/lib/auth";
+import { checkRateLimit, resetRateLimit } from "@/lib/rateLimit";
+
+const LOGIN_RATE_LIMIT = { max: 5, windowMs: 15 * 60 * 1000 };
+
+function getClientIp(req: NextRequest): string {
+  const forwardedFor = req.headers.get("x-forwarded-for");
+  if (forwardedFor) return forwardedFor.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
 
 export async function POST(req: NextRequest) {
+  const rateLimitKey = `admin-login:${getClientIp(req)}`;
+  const { allowed, resetAt } = checkRateLimit(rateLimitKey, LOGIN_RATE_LIMIT);
+
+  if (!allowed) {
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((resetAt - Date.now()) / 1000)
+    );
+    return NextResponse.json(
+      { error: "Demasiados intentos. Probá de nuevo más tarde." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(retryAfterSeconds) },
+      }
+    );
+  }
+
   const { password } = await req.json();
 
   if (!checkAdminPassword(password)) {
     return NextResponse.json({ error: "Contraseña incorrecta" }, { status: 401 });
   }
+
+  resetRateLimit(rateLimitKey);
 
   const token = await signToken({ role: "admin" });
 

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,53 @@
+/**
+ * Rate limiter en memoria, best-effort. Pensado para endpoints de bajo
+ * tráfico (ej. login del admin) donde alcanza con un freno básico contra
+ * fuerza bruta.
+ *
+ * Limitación conocida: el estado vive en memoria del proceso, así que no es
+ * consistente entre instancias serverless concurrentes ni sobrevive a un
+ * redeploy/cold start. Para algo más estricto hace falta un store
+ * compartido (Redis, Vercel KV, etc.) — no vale la pena la complejidad para
+ * el volumen de tráfico actual de este proyecto.
+ */
+
+type Bucket = {
+  count: number;
+  resetAt: number;
+};
+
+const buckets = new Map<string, Bucket>();
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+};
+
+export function checkRateLimit(
+  key: string,
+  { max, windowMs }: { max: number; windowMs: number }
+): RateLimitResult {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    const resetAt = now + windowMs;
+    buckets.set(key, { count: 1, resetAt });
+    return { allowed: true, remaining: max - 1, resetAt };
+  }
+
+  if (bucket.count >= max) {
+    return { allowed: false, remaining: 0, resetAt: bucket.resetAt };
+  }
+
+  bucket.count += 1;
+  return {
+    allowed: true,
+    remaining: max - bucket.count,
+    resetAt: bucket.resetAt,
+  };
+}
+
+export function resetRateLimit(key: string): void {
+  buckets.delete(key);
+}

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -17,6 +17,19 @@ type Bucket = {
 
 const buckets = new Map<string, Bucket>();
 
+// Barrido periódico de entradas vencidas para que el Map no crezca sin
+// límite (ej. muchas IPs distintas pegándole al endpoint). No hace falta
+// un timer de background: alcanza con revisar cada tanto en el propio
+// camino de checkRateLimit.
+const SWEEP_INTERVAL_CALLS = 100;
+let callsSinceSweep = 0;
+
+function sweepExpired(now: number): void {
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+}
+
 export type RateLimitResult = {
   allowed: boolean;
   remaining: number;
@@ -28,6 +41,13 @@ export function checkRateLimit(
   { max, windowMs }: { max: number; windowMs: number }
 ): RateLimitResult {
   const now = Date.now();
+
+  callsSinceSweep += 1;
+  if (callsSinceSweep >= SWEEP_INTERVAL_CALLS) {
+    callsSinceSweep = 0;
+    sweepExpired(now);
+  }
+
   const bucket = buckets.get(key);
 
   if (!bucket || bucket.resetAt <= now) {

--- a/tests/integration/admin-auth.test.ts
+++ b/tests/integration/admin-auth.test.ts
@@ -54,8 +54,10 @@ describe("POST /api/admin/login", () => {
   it("resetea el contador de intentos tras un login exitoso", async () => {
     const ip = "203.0.113.20";
 
-    await login(loginRequest("contraseña-incorrecta", ip));
-    await login(loginRequest("contraseña-incorrecta", ip));
+    // 4 de los 5 intentos permitidos, para probar el reset justo al límite.
+    for (let i = 0; i < 4; i++) {
+      await login(loginRequest("contraseña-incorrecta", ip));
+    }
 
     const ok = await login(loginRequest(CORRECT_PASSWORD, ip));
     expect(ok.status).toBe(200);

--- a/tests/integration/admin-auth.test.ts
+++ b/tests/integration/admin-auth.test.ts
@@ -6,10 +6,11 @@ import { verifyToken } from "@/lib/auth";
 
 const CORRECT_PASSWORD = process.env.ADMIN_PASSWORD as string;
 
-function loginRequest(password: string) {
+function loginRequest(password: string, ip?: string) {
   return new NextRequest("http://localhost/api/admin/login", {
     method: "POST",
     body: JSON.stringify({ password }),
+    headers: ip ? { "x-forwarded-for": ip } : undefined,
   });
 }
 
@@ -35,6 +36,33 @@ describe("POST /api/admin/login", () => {
     const token = res.cookies.get("admin_token")?.value ?? "";
     const payload = await verifyToken(token);
     expect(payload).not.toBeNull();
+  });
+
+  it("bloquea con 429 tras 5 intentos fallidos desde la misma IP", async () => {
+    const ip = "203.0.113.10";
+
+    for (let i = 0; i < 5; i++) {
+      const res = await login(loginRequest("contraseña-incorrecta", ip));
+      expect(res.status).toBe(401);
+    }
+
+    const blocked = await login(loginRequest(CORRECT_PASSWORD, ip));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("resetea el contador de intentos tras un login exitoso", async () => {
+    const ip = "203.0.113.20";
+
+    await login(loginRequest("contraseña-incorrecta", ip));
+    await login(loginRequest("contraseña-incorrecta", ip));
+
+    const ok = await login(loginRequest(CORRECT_PASSWORD, ip));
+    expect(ok.status).toBe(200);
+
+    // Tras el reset, un intento fallido nuevo no debería estar ya al límite.
+    const afterReset = await login(loginRequest("contraseña-incorrecta", ip));
+    expect(afterReset.status).toBe(401);
   });
 });
 


### PR DESCRIPTION
## Ticket
[BRT-107](https://brot74.atlassian.net/browse/BRT-107)

## Qué cambia
`/api/admin/login` no tenía ningún límite de intentos. Con el repo ahora público, el mecanismo exacto del endpoint (forma del request, comparación simple) queda visible para cualquiera sin tener que adivinarlo — facilita fuerza bruta contra la contraseña compartida del admin.

- `lib/rateLimit.ts`: rate limiter en memoria, best-effort. Documentado en el propio archivo que es por-instancia serverless (no sobrevive a un redeploy) — suficiente para el volumen de tráfico de este proyecto, no vale la pena la complejidad de un store compartido (Redis/Vercel KV) todavía.
- `app/api/admin/login/route.ts`: máximo 5 intentos cada 15 min por IP (`x-forwarded-for`/`x-real-ip`), `429` + header `Retry-After` al superar el límite, contador se resetea al loguearse OK.
- Tests nuevos: bloqueo tras 5 fallos consecutivos, reset del contador tras un login exitoso.

## Verificación
- `npm test` → 89/89 OK (local, Postgres de test)
- `npm run lint` → 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-107]: https://brot74.atlassian.net/browse/BRT-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Admin login now limits attempts to five per IP address within 15 minutes.
  * Blocked login requests return a temporary lockout response with retry timing.

* **Bug Fixes**
  * Successful authentication resets the failed-attempt counter, allowing normal access afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->