### PR TITLE
fix(BRT-108,BRT-109): validar cantidades y hacer atómica la reserva de stock

### DIFF
--- a/app/api/cart/reserve/route.ts
+++ b/app/api/cart/reserve/route.ts
@@ -1,15 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { randomUUID } from "crypto";
+import { normalizeCartItems } from "@/lib/cartItems";
 
 const TTL_MS = 15 * 60 * 1000;
 
 export async function POST(req: NextRequest) {
   try {
-    const { slotId, items } = await req.json();
+    const { slotId, items: rawItems } = await req.json();
 
-    if (!slotId || !items?.length) {
+    if (!slotId) {
       return NextResponse.json({ error: "Datos incompletos" }, { status: 400 });
+    }
+
+    const items = normalizeCartItems(rawItems);
+    if (!items) {
+      return NextResponse.json(
+        { error: "Cantidades inválidas" },
+        { status: 400 }
+      );
     }
 
     const now = new Date();
@@ -20,7 +29,7 @@ export async function POST(req: NextRequest) {
       where: { deliverySlotId: slotId, expiresAt: { lt: now } },
     });
 
-    for (const item of items as { productId: number; quantity: number }[]) {
+    for (const item of items) {
       const stock = await prisma.productStock.findUnique({
         where: { productId_deliverySlotId: { productId: item.productId, deliverySlotId: slotId } },
       });
@@ -49,7 +58,7 @@ export async function POST(req: NextRequest) {
     const sessionToken = randomUUID();
 
     await prisma.cartReservation.createMany({
-      data: (items as { productId: number; quantity: number }[]).map((item) => ({
+      data: items.map((item) => ({
         productId: item.productId,
         deliverySlotId: slotId,
         quantity: item.quantity,

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -1,14 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { sendWhatsAppNotification, buildOrderMessage } from "@/lib/whatsapp";
+import { normalizeCartItems } from "@/lib/cartItems";
+
+class InsufficientStockError extends Error {
+  constructor(public productId: number, public productName: string) {
+    super(`Stock insuficiente para ${productName}`);
+  }
+}
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { customerName, customerPhone, deliverySlotId, items, notes, sessionToken } = body;
+    const { customerName, customerPhone, deliverySlotId, items: rawItems, notes, sessionToken } = body;
 
-    if (!customerName || !customerPhone || !deliverySlotId || !items?.length) {
+    if (!customerName || !customerPhone || !deliverySlotId) {
       return NextResponse.json({ error: "Datos incompletos" }, { status: 400 });
+    }
+
+    const items = normalizeCartItems(rawItems);
+    if (!items) {
+      return NextResponse.json({ error: "Cantidades inválidas" }, { status: 400 });
     }
 
     const slot = await prisma.deliverySlot.findUnique({ where: { id: deliverySlotId } });
@@ -25,7 +37,7 @@ export async function POST(req: NextRequest) {
       });
       if (reservations.length > 0) {
         const resMap = new Map(reservations.map((r) => [r.productId, r.quantity]));
-        reservationValid = (items as { productId: number; quantity: number }[]).every(
+        reservationValid = items.every(
           (item) => (resMap.get(item.productId) ?? 0) >= item.quantity
         );
       }
@@ -38,8 +50,12 @@ export async function POST(req: NextRequest) {
     // Verify stock and calculate total
     let total = 0;
     const enrichedItems: { productId: number; quantity: number; unitPrice: number; name: string }[] = [];
+    // Productos con fila de ProductStock — solo a estos se les aplica el
+    // update atómico dentro de la transacción (BRT-109). Si no hay fila,
+    // se preserva el comportamiento existente de no limitar el stock.
+    const productsWithStock = new Set<number>();
 
-    for (const item of items as { productId: number; quantity: number }[]) {
+    for (const item of items) {
       const product = await prisma.product.findUnique({ where: { id: item.productId } });
       if (!product || !product.active) {
         return NextResponse.json({ error: `Producto no disponible: ${item.productId}` }, { status: 400 });
@@ -50,6 +66,8 @@ export async function POST(req: NextRequest) {
       });
 
       if (stock) {
+        productsWithStock.add(item.productId);
+
         let available: number;
         if (reservationValid) {
           // The reservation already holds this stock — only count confirmed orders
@@ -73,38 +91,59 @@ export async function POST(req: NextRequest) {
     }
 
     // Create order, reserve stock, and release cart reservation — all in one transaction
-    const order = await prisma.$transaction(async (tx) => {
-      const newOrder = await tx.order.create({
-        data: {
-          customerName,
-          customerPhone,
-          deliverySlotId,
-          total,
-          notes: notes ?? "",
-          status: "pending",
-          items: {
-            create: enrichedItems.map((i) => ({
-              productId: i.productId,
-              quantity: i.quantity,
-              unitPrice: i.unitPrice,
-            })),
+    let order;
+    try {
+      order = await prisma.$transaction(async (tx) => {
+        const newOrder = await tx.order.create({
+          data: {
+            customerName,
+            customerPhone,
+            deliverySlotId,
+            total,
+            notes: notes ?? "",
+            status: "pending",
+            items: {
+              create: enrichedItems.map((i) => ({
+                productId: i.productId,
+                quantity: i.quantity,
+                unitPrice: i.unitPrice,
+              })),
+            },
           },
-        },
-      });
-
-      for (const item of enrichedItems) {
-        await tx.productStock.updateMany({
-          where: { productId: item.productId, deliverySlotId },
-          data: { reservedStock: { increment: item.quantity } },
         });
-      }
 
-      if (sessionToken) {
-        await tx.cartReservation.deleteMany({ where: { sessionToken } });
-      }
+        for (const item of enrichedItems) {
+          if (!productsWithStock.has(item.productId)) continue;
 
-      return newOrder;
-    });
+          // Update atómico: solo incrementa reservedStock si todavía hay
+          // capacidad en ese momento exacto (BRT-109). Si dos requests
+          // concurrentes compiten por el mismo stock, como mucho una de
+          // las dos consigue afectar la fila.
+          const affected = await tx.$executeRaw`
+            UPDATE "ProductStock"
+            SET "reservedStock" = "reservedStock" + ${item.quantity}
+            WHERE "productId" = ${item.productId}
+              AND "deliverySlotId" = ${deliverySlotId}
+              AND "totalStock" - "reservedStock" >= ${item.quantity}
+          `;
+
+          if (affected === 0) {
+            throw new InsufficientStockError(item.productId, item.name);
+          }
+        }
+
+        if (sessionToken) {
+          await tx.cartReservation.deleteMany({ where: { sessionToken } });
+        }
+
+        return newOrder;
+      });
+    } catch (e) {
+      if (e instanceof InsufficientStockError) {
+        return NextResponse.json({ error: e.message }, { status: 409 });
+      }
+      throw e;
+    }
 
     try {
       const msg = buildOrderMessage({

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -112,9 +112,15 @@ export async function POST(req: NextRequest) {
           },
         });
 
-        for (const item of enrichedItems) {
-          if (!productsWithStock.has(item.productId)) continue;
+        // Orden consistente (por productId) al tomar los locks de fila de
+        // ProductStock: si dos pedidos concurrentes comparten productos
+        // pero los mandan en orden distinto, sin esto podrían deadlockear
+        // entre sí en vez de simplemente competir por el stock.
+        const stockUpdates = enrichedItems
+          .filter((item) => productsWithStock.has(item.productId))
+          .sort((a, b) => a.productId - b.productId);
 
+        for (const item of stockUpdates) {
           // Update atómico: solo incrementa reservedStock si todavía hay
           // capacidad en ese momento exacto (BRT-109). Si dos requests
           // concurrentes compiten por el mismo stock, como mucho una de

--- a/lib/cartItems.ts
+++ b/lib/cartItems.ts
@@ -1,0 +1,41 @@
+/**
+ * Valida y normaliza los `items` que llegan del cliente en
+ * /api/cart/reserve y /api/orders (BRT-108).
+ *
+ * - Rechaza cualquier `productId`/`quantity` que no sea un entero positivo.
+ * - Consolida líneas repetidas del mismo `productId`, sumando cantidades,
+ *   para que no se pueda superar el stock disponible partiendo el mismo
+ *   pedido en varias líneas.
+ */
+
+export type CartItem = {
+  productId: number;
+  quantity: number;
+};
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+export function normalizeCartItems(items: unknown): CartItem[] | null {
+  if (!Array.isArray(items) || items.length === 0) return null;
+
+  const consolidated = new Map<number, number>();
+
+  for (const raw of items) {
+    if (typeof raw !== "object" || raw === null) return null;
+
+    const { productId, quantity } = raw as Record<string, unknown>;
+
+    if (!isPositiveInteger(productId) || !isPositiveInteger(quantity)) {
+      return null;
+    }
+
+    consolidated.set(productId, (consolidated.get(productId) ?? 0) + quantity);
+  }
+
+  return Array.from(consolidated, ([productId, quantity]) => ({
+    productId,
+    quantity,
+  }));
+}

--- a/lib/cartItems.ts
+++ b/lib/cartItems.ts
@@ -13,8 +13,18 @@ export type CartItem = {
   quantity: number;
 };
 
+// Los campos correspondientes son Int en el schema de Prisma (32 bits).
+// Un valor más grande rompe en la query con un error feo (500) en vez de
+// un 400 limpio.
+const MAX_INT32 = 2147483647;
+
 function isPositiveInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value > 0 &&
+    value <= MAX_INT32
+  );
 }
 
 export function normalizeCartItems(items: unknown): CartItem[] | null {
@@ -32,6 +42,12 @@ export function normalizeCartItems(items: unknown): CartItem[] | null {
     }
 
     consolidated.set(productId, (consolidated.get(productId) ?? 0) + quantity);
+  }
+
+  // La suma de líneas duplicadas también puede superar el límite aunque
+  // cada línea individual estuviera dentro de rango.
+  for (const quantity of consolidated.values()) {
+    if (quantity > MAX_INT32) return null;
   }
 
   return Array.from(consolidated, ([productId, quantity]) => ({

--- a/tests/integration/cart-reserve.test.ts
+++ b/tests/integration/cart-reserve.test.ts
@@ -61,7 +61,7 @@ describe("POST /api/cart/reserve", () => {
     const slot = await createDeliverySlot();
     await createProductStock(product.id, slot.id, { totalStock: 5 });
 
-    for (const quantity of [-5, 0, 1.5]) {
+    for (const quantity of [-5, 0, 1.5, 2147483648]) {
       const res = await POST(
         makeRequest({ slotId: slot.id, items: [{ productId: product.id, quantity }] })
       );

--- a/tests/integration/cart-reserve.test.ts
+++ b/tests/integration/cart-reserve.test.ts
@@ -55,4 +55,40 @@ describe("POST /api/cart/reserve", () => {
     const res = await POST(makeRequest({ slotId: null, items: [] }));
     expect(res.status).toBe(400);
   });
+
+  it("devuelve 400 con quantity negativa, cero, o no entera (BRT-108)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    for (const quantity of [-5, 0, 1.5]) {
+      const res = await POST(
+        makeRequest({ slotId: slot.id, items: [{ productId: product.id, quantity }] })
+      );
+      expect(res.status).toBe(400);
+    }
+
+    const reservations = await prisma.cartReservation.findMany({ where: { productId: product.id } });
+    expect(reservations).toHaveLength(0);
+  });
+
+  it("consolida líneas duplicadas del mismo productId antes de validar stock (BRT-108)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    // 3 + 3 = 6, supera el stock total de 5 aunque cada línea individual
+    // (3) esté por debajo.
+    const res = await POST(
+      makeRequest({
+        slotId: slot.id,
+        items: [
+          { productId: product.id, quantity: 3 },
+          { productId: product.id, quantity: 3 },
+        ],
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
 });

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -119,7 +119,7 @@ describe("POST /api/orders", () => {
     const slot = await createDeliverySlot();
     await createProductStock(product.id, slot.id, { totalStock: 5 });
 
-    for (const quantity of [-5, 0, 1.5]) {
+    for (const quantity of [-5, 0, 1.5, 2147483648]) {
       const res = await POST(
         makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity }] }))
       );
@@ -174,5 +174,44 @@ describe("POST /api/orders", () => {
 
     const orders = await prisma.order.findMany();
     expect(orders).toHaveLength(1);
+  });
+
+  it("no deadlockea con pedidos concurrentes que comparten productos en orden inverso (BRT-109)", async () => {
+    const productA = await createProduct();
+    const productB = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(productA.id, slot.id, { totalStock: 5 });
+    await createProductStock(productB.id, slot.id, { totalStock: 5 });
+
+    const [resA, resB] = await Promise.all([
+      POST(
+        makeRequest(
+          baseOrder({
+            deliverySlotId: slot.id,
+            items: [
+              { productId: productA.id, quantity: 1 },
+              { productId: productB.id, quantity: 1 },
+            ],
+          })
+        )
+      ),
+      POST(
+        makeRequest(
+          baseOrder({
+            deliverySlotId: slot.id,
+            items: [
+              { productId: productB.id, quantity: 1 },
+              { productId: productA.id, quantity: 1 },
+            ],
+          })
+        )
+      ),
+    ]);
+
+    // Con stock de sobra para ambos, si hubiera un deadlock por orden de
+    // locks inconsistente, Postgres abortaría una de las dos transacciones
+    // y devolveríamos 500 en vez de 200.
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
   });
 });

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -113,4 +113,66 @@ describe("POST /api/orders", () => {
 
     expect(res.status).toBe(200);
   });
+
+  it("devuelve 400 con quantity negativa, cero, o no entera (BRT-108)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    for (const quantity of [-5, 0, 1.5]) {
+      const res = await POST(
+        makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity }] }))
+      );
+      expect(res.status).toBe(400);
+    }
+
+    const orders = await prisma.order.findMany();
+    expect(orders).toHaveLength(0);
+  });
+
+  it("consolida líneas duplicadas del mismo productId antes de validar stock (BRT-108)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    const res = await POST(
+      makeRequest(
+        baseOrder({
+          deliverySlotId: slot.id,
+          items: [
+            { productId: product.id, quantity: 3 },
+            { productId: product.id, quantity: 3 },
+          ],
+        })
+      )
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("evita sobreventa con dos pedidos concurrentes por el último stock (BRT-109)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 1, reservedStock: 0 });
+
+    const [resA, resB] = await Promise.all([
+      POST(
+        makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+      ),
+      POST(
+        makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+      ),
+    ]);
+
+    const statuses = [resA.status, resB.status].sort();
+    expect(statuses).toEqual([200, 409]);
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    expect(stock?.reservedStock).toBe(1);
+
+    const orders = await prisma.order.findMany();
+    expect(orders).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Tickets
[BRT-108](https://brot74.atlassian.net/browse/BRT-108) — cantidades sin validar
[BRT-109](https://brot74.atlassian.net/browse/BRT-109) — race condition en /api/orders

Ambos surgieron de una revisión hecha con Codex por un colaborador externo ([PR #59](https://github.com/gastton/brot74-web/pull/59)), verificados contra el código real antes de implementar el fix.

## BRT-108 — cantidades sin validar
`quantity` se usaba tal cual llegaba del cliente en `/api/cart/reserve` y `/api/orders`. Una cantidad negativa pasaba el chequeo de disponibilidad y después restaba del `cartHeld` agregado, inflando el stock disponible para otros clientes. Productos duplicados en `items` tampoco se consolidaban.

- `lib/cartItems.ts`: `normalizeCartItems()` valida enteros positivos (≥1) y consolida líneas duplicadas por `productId`.
- Aplicado en ambos endpoints.

## BRT-109 — race condition en /api/orders
El chequeo de disponibilidad ocurría antes de la `$transaction`, y el `updateMany` que incrementaba `reservedStock` no tenía ninguna condición que revalidara el stock en ese momento — dos requests concurrentes por el mismo producto/fecha podían sobrevender.

- El increment ahora es un `UPDATE` condicional (`tx.$executeRaw`) que solo afecta la fila si `totalStock - reservedStock >= quantity` en ese instante. Si no afecta ninguna fila, aborta la transacción con `409`.
- Solo aplica a productos que ya tenían fila de `ProductStock` — no cambia el comportamiento de los que no la tienen (gap aparte, fuera de este ticket).

## Verificación
- Tests nuevos: cantidades inválidas en ambos endpoints, consolidación de duplicados, y una prueba de concurrencia real con `Promise.all` contra Postgres que confirma que de dos pedidos simultáneos por el último stock, solo uno gana (verifiqué localmente antes de escribir el fix que sin él la prueba fallaba con sobreventa).
- `npm test` → 92/92 OK
- `npm run lint` → 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-108]: https://brot74.atlassian.net/browse/BRT-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-109]: https://brot74.atlassian.net/browse/BRT-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid cart quantities are now rejected with a 400 response.
  - Duplicate cart lines are combined before stock validation.
  - Improved protection against overselling during concurrent reservations and orders.
  - Failed reservations no longer create incomplete orders or alter inventory.

- **Tests**
  - Added coverage for invalid quantities, duplicate items, stock conflicts, and concurrent ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->