### PR TITLE
fix(BRT-117): respetar el stock disponible en el quick-add de la card

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -208,7 +208,17 @@ function HomeContent() {
   }
 
   function addToCart(productId: number) {
-    setCart((prev) => ({ ...prev, [productId]: (prev[productId] ?? 0) + 1 }));
+    setCart((prev) => {
+      const current = prev[productId] ?? 0;
+      const product = products.find((p) => p.id === productId);
+      // Tope defensivo (BRT-117): el "+" de la card ya se deshabilita al
+      // llegar al stock disponible, pero clicks disparados a mansalva
+      // pueden encolarse antes de que React vuelva a renderizar el botón
+      // deshabilitado. El updater funcional ve siempre el último `prev`,
+      // así que este chequeo alcanza incluso en ese caso.
+      if (product && product.stock !== null && current >= product.stock) return prev;
+      return { ...prev, [productId]: current + 1 };
+    });
   }
 
   function removeFromCart(productId: number) {

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -40,6 +40,10 @@ export default function ProductCard({
   const remaining = stock !== null ? stock - quantity : null;
   const outOfStock = slotSelected && !hasStock && stock !== null && stock <= 0;
   const isDisabled = !slotSelected || outOfStock;
+  // BRT-117: además del caso "sin stock para nadie" (outOfStock), el "+" de
+  // quick-add tiene que respetar lo que ya hay en el carrito — mismo límite
+  // que ya usa el "+" del modal de detalle (ver ProductModal canAdd).
+  const limitReached = remaining !== null && remaining <= 0;
 
   return (
     <div
@@ -131,22 +135,28 @@ export default function ProductCard({
         )}
 
         {/* Quick-add (BRT-89): suma 1 unidad sin abrir el modal de producto.
-           Mismo lenguaje visual que el botón "Volver" de ProductModal. */}
+           Mismo lenguaje visual que el botón "Volver" de ProductModal. Sigue
+           visible cuando se llega al límite (BRT-117) —igual que el modal—
+           pero deshabilitado, para que quede claro que ya no se puede sumar
+           más sin tener que abrir el modal para verlo. */}
         {!isDisabled && (
           <button
             type="button"
             aria-label={`Agregar ${name}`}
-            onClick={(e) => { e.stopPropagation(); onQuickAdd(); }}
+            aria-disabled={limitReached}
+            disabled={limitReached}
+            onClick={(e) => { e.stopPropagation(); if (!limitReached) onQuickAdd(); }}
             className="absolute bottom-2 right-2 w-9 h-9 rounded-full flex items-center justify-center border-none"
             style={{
               background: "rgba(248,243,234,.9)",
               backdropFilter: "blur(6px)",
               WebkitBackdropFilter: "blur(6px)",
               boxShadow: "0 3px 10px -4px rgba(0,0,0,.4)",
-              cursor: "pointer",
-              transition: "transform .15s",
+              cursor: limitReached ? "not-allowed" : "pointer",
+              opacity: limitReached ? 0.45 : 1,
+              transition: "transform .15s, opacity .15s",
             }}
-            onMouseDown={(e) => { e.currentTarget.style.transform = "scale(.9)"; }}
+            onMouseDown={(e) => { if (!limitReached) e.currentTarget.style.transform = "scale(.9)"; }}
             onMouseUp={(e) => { e.currentTarget.style.transform = ""; }}
             onMouseLeave={(e) => { e.currentTarget.style.transform = ""; }}
           >


### PR DESCRIPTION
## Resumen

El botón "+" de quick-add en `ProductCard` solo se deshabilitaba cuando el stock total llegaba a 0 (`outOfStock`), nunca comparaba contra `remaining = stock - quantity` (ya calculado en el componente, pero sin usar para el disabled). Haciendo click repetido se podía acumular en el carrito más cantidad que el stock disponible — inconsistente con el "+" del modal de detalle de producto, que sí respeta ese límite (`canAdd`).

- **`components/ProductCard.tsx`** — nuevo `limitReached` (`remaining <= 0`) deshabilita el botón de quick-add. Se mantiene visible (igual que el botón del modal cuando no hay disponibilidad), solo se deshabilita, para que quede claro que se llegó al tope sin tener que abrir el modal. No afecta si la card entera sigue siendo clickeable para abrir el modal (ahí el usuario puede restar cantidad).
- **`app/page.tsx`** — `addToCart()` suma un tope defensivo contra `product.stock`, usando el updater funcional de `setCart`. El botón deshabilitado ya cubre el caso normal, pero clicks disparados a mansalva pueden encolarse antes de que React vuelva a renderizar el botón deshabilitado — el updater funcional sí ve siempre el último valor real de `prev`, así que frena ahí también.

Sin cambios para productos con `stock === null` (sin tope), como pide el ticket.

Fixes [BRT-117](https://brot74.atlassian.net/browse/BRT-117).

## Test plan
- [x] `npx tsc --noEmit` — sin errores.
- [x] `npx eslint components/ProductCard.tsx app/page.tsx` — 0 errores (los warnings preexistentes de `set-state-in-effect`/`security/detect-object-injection` ya están aceptados en el resto del archivo).
- [x] `npx vitest run` (suite completa) — 95/95 pasan.
- [x] Verificación manual en navegador con un producto sembrado a stock=2: clickeando "+" repetidas veces la cantidad para en 2, el botón queda `disabled` (confirmado también con clicks de más, no suma), y se reactiva al bajar la cantidad a 1 desde el modal. El "+" del modal se comporta igual que antes ("0 disponibles").

[BRT-117]: https://brot74.atlassian.net/browse/BRT-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cart quantities from exceeding a product’s available stock.
  * Disabled quick-add controls when the stock limit is reached.
  * Added accessible disabled-state indicators and updated visual feedback for unavailable additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->