### PR TITLE
docs: convención de testing (integration sí, unit no, positivo+negativo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,9 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# Testing
+
+- No unit tests in this project, and none planned — `tests/integration/**` (Vitest + Postgres real, sin mocks de Prisma) ya cubre la lógica pura de `lib/**` indirectamente a través de los endpoints que la usan. No agregar una capa de unit tests separada.
+- Todo cambio de comportamiento en `app/api/**` lleva, como mínimo, un test de integración **positivo** (camino feliz) y uno **negativo** (rechazo/error/caso límite) en `tests/integration/`, en el mismo PR del fix o feature.
+- La UI (componentes en `app/**`/`components/**`) se valida manualmente por ahora — no hay Playwright ni tests de UI todavía.


### PR DESCRIPTION
Acordado en sesión de code review: sin unit tests (la cobertura de integración ya alcanza para la lógica pura de `lib/`), y todo cambio de comportamiento en `app/api/**` lleva un test positivo y uno negativo como mínimo, en el mismo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added testing guidelines covering integration tests for API changes and manual validation for UI updates.
  * Clarified that the project does not maintain a separate unit-test layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->