### PR TITLE
fix(BRT-110,BRT-113): filtrar reserva por fecha y no saltear stock faltante

### DIFF
--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -32,8 +32,11 @@ export async function POST(req: NextRequest) {
     const now = new Date();
     let reservationValid = false;
     if (sessionToken) {
+      // BRT-110: filtrar también por deliverySlotId — si no, una reserva de
+      // carrito activa para otra fecha de entrega se confunde con la de
+      // este pedido (y más abajo se borraría por error).
       const reservations = await prisma.cartReservation.findMany({
-        where: { sessionToken, expiresAt: { gt: now } },
+        where: { sessionToken, deliverySlotId, expiresAt: { gt: now } },
       });
       if (reservations.length > 0) {
         const resMap = new Map(reservations.map((r) => [r.productId, r.quantity]));
@@ -50,10 +53,6 @@ export async function POST(req: NextRequest) {
     // Verify stock and calculate total
     let total = 0;
     const enrichedItems: { productId: number; quantity: number; unitPrice: number; name: string }[] = [];
-    // Productos con fila de ProductStock — solo a estos se les aplica el
-    // update atómico dentro de la transacción (BRT-109). Si no hay fila,
-    // se preserva el comportamiento existente de no limitar el stock.
-    const productsWithStock = new Set<number>();
 
     for (const item of items) {
       const product = await prisma.product.findUnique({ where: { id: item.productId } });
@@ -65,25 +64,31 @@ export async function POST(req: NextRequest) {
         where: { productId_deliverySlotId: { productId: item.productId, deliverySlotId } },
       });
 
-      if (stock) {
-        productsWithStock.add(item.productId);
+      // BRT-113: sin fila de ProductStock para este producto+fecha se trata
+      // como 0 disponible, no como "sin límite" — antes el pedido pasaba
+      // sin ninguna validación de stock para ese ítem.
+      if (!stock) {
+        return NextResponse.json(
+          { error: `Stock no disponible para ${product.name}` },
+          { status: 400 }
+        );
+      }
 
-        let available: number;
-        if (reservationValid) {
-          // The reservation already holds this stock — only count confirmed orders
-          available = stock.totalStock - stock.reservedStock;
-        } else {
-          // No reservation: deduct active cart reservations too
-          const agg = await prisma.cartReservation.aggregate({
-            where: { productId: item.productId, deliverySlotId, expiresAt: { gt: now } },
-            _sum: { quantity: true },
-          });
-          available = stock.totalStock - stock.reservedStock - (agg._sum.quantity ?? 0);
-        }
+      let available: number;
+      if (reservationValid) {
+        // The reservation already holds this stock — only count confirmed orders
+        available = stock.totalStock - stock.reservedStock;
+      } else {
+        // No reservation: deduct active cart reservations too
+        const agg = await prisma.cartReservation.aggregate({
+          where: { productId: item.productId, deliverySlotId, expiresAt: { gt: now } },
+          _sum: { quantity: true },
+        });
+        available = stock.totalStock - stock.reservedStock - (agg._sum.quantity ?? 0);
+      }
 
-        if (available < item.quantity) {
-          return NextResponse.json({ error: `Stock insuficiente para ${product.name}` }, { status: 400 });
-        }
+      if (available < item.quantity) {
+        return NextResponse.json({ error: `Stock insuficiente para ${product.name}` }, { status: 400 });
       }
 
       total += product.price * item.quantity;
@@ -116,9 +121,9 @@ export async function POST(req: NextRequest) {
         // ProductStock: si dos pedidos concurrentes comparten productos
         // pero los mandan en orden distinto, sin esto podrían deadlockear
         // entre sí en vez de simplemente competir por el stock.
-        const stockUpdates = enrichedItems
-          .filter((item) => productsWithStock.has(item.productId))
-          .sort((a, b) => a.productId - b.productId);
+        // Desde BRT-113, todo item en enrichedItems tiene garantizada su
+        // fila de ProductStock (si no existía, ya se rechazó antes).
+        const stockUpdates = [...enrichedItems].sort((a, b) => a.productId - b.productId);
 
         for (const item of stockUpdates) {
           // Update atómico: solo incrementa reservedStock si todavía hay
@@ -139,7 +144,9 @@ export async function POST(req: NextRequest) {
         }
 
         if (sessionToken) {
-          await tx.cartReservation.deleteMany({ where: { sessionToken } });
+          // BRT-110: solo la reserva de esta fecha, no todas las del
+          // sessionToken — una reserva activa de otra fecha no se toca.
+          await tx.cartReservation.deleteMany({ where: { sessionToken, deliverySlotId } });
         }
 
         return newOrder;

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -214,4 +214,97 @@ describe("POST /api/orders", () => {
     expect(resA.status).toBe(200);
     expect(resB.status).toBe(200);
   });
+
+  it("devuelve 400 si no existe ProductStock para el producto+fecha (BRT-113)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    // A propósito: no se crea ProductStock para este producto+fecha.
+
+    const res = await POST(
+      makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+    );
+
+    expect(res.status).toBe(400);
+
+    const orders = await prisma.order.findMany();
+    expect(orders).toHaveLength(0);
+  });
+
+  it("crea el pedido normalmente cuando sí existe ProductStock (BRT-113)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    const res = await POST(
+      makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("solo consume la reserva de carrito de la fecha del pedido, no las de otras fechas (BRT-110)", async () => {
+    const product = await createProduct();
+    const slotA = await createDeliverySlot();
+    const slotB = await createDeliverySlot();
+    await createProductStock(product.id, slotA.id, { totalStock: 5 });
+    await createProductStock(product.id, slotB.id, { totalStock: 5 });
+
+    const sessionToken = crypto.randomUUID();
+    await createCartReservation(product.id, slotA.id, { sessionToken, quantity: 1 });
+    // Reserva activa para slotB, con el mismo productId — no debería
+    // confundirse con la de slotA ni borrarse al confirmar el pedido de A.
+    await createCartReservation(product.id, slotB.id, { sessionToken, quantity: 2 });
+
+    const res = await POST(
+      makeRequest(
+        baseOrder({
+          deliverySlotId: slotA.id,
+          items: [{ productId: product.id, quantity: 1 }],
+          sessionToken,
+        })
+      )
+    );
+
+    expect(res.status).toBe(200);
+
+    const reservationsA = await prisma.cartReservation.findMany({
+      where: { sessionToken, deliverySlotId: slotA.id },
+    });
+    expect(reservationsA).toHaveLength(0);
+
+    const reservationsB = await prisma.cartReservation.findMany({
+      where: { sessionToken, deliverySlotId: slotB.id },
+    });
+    expect(reservationsB).toHaveLength(1);
+    expect(reservationsB[0].quantity).toBe(2);
+  });
+
+  it("devuelve 409 si el sessionToken no tiene reserva para la fecha del pedido (BRT-110)", async () => {
+    const product = await createProduct();
+    const slotA = await createDeliverySlot();
+    const slotB = await createDeliverySlot();
+    await createProductStock(product.id, slotA.id, { totalStock: 5 });
+    await createProductStock(product.id, slotB.id, { totalStock: 5 });
+
+    const sessionToken = crypto.randomUUID();
+    // Reserva únicamente para slotB — el pedido es para slotA.
+    await createCartReservation(product.id, slotB.id, { sessionToken, quantity: 1 });
+
+    const res = await POST(
+      makeRequest(
+        baseOrder({
+          deliverySlotId: slotA.id,
+          items: [{ productId: product.id, quantity: 1 }],
+          sessionToken,
+        })
+      )
+    );
+
+    expect(res.status).toBe(409);
+
+    const reservationsB = await prisma.cartReservation.findMany({
+      where: { sessionToken, deliverySlotId: slotB.id },
+    });
+    expect(reservationsB).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Tickets
[BRT-110](https://brot74.atlassian.net/browse/BRT-110) — reserva de carrito no filtrada por deliverySlotId
[BRT-113](https://brot74.atlassian.net/browse/BRT-113) — ProductStock faltante salta la validación

## BRT-110
La búsqueda y el borrado de `CartReservation` en `/api/orders` solo filtraban por `sessionToken`, sin `deliverySlotId`. Al confirmar un pedido se borraban **todas** las reservas de ese `sessionToken`, incluidas las de otras fechas — se perdían silenciosamente sin aviso. Ahora ambas queries filtran también por `deliverySlotId`.

## BRT-113
Si no existía fila de `ProductStock` para un producto+fecha, el chequeo de disponibilidad se saltaba por completo y el pedido se creaba sin validar stock. Ahora se trata como 0 disponible: 400 en vez de pasar sin control. De yapa simplifica el update atómico de BRT-109 (ya no hace falta trackear qué productos tienen stock).

## Verificación
- Tests nuevos: reserva de otra fecha no se toca, 409 si el sessionToken no cubre la fecha del pedido, 400/200 según haya o no ProductStock.
- `npm test` → 99/99 OK
- `npm run lint` → 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-110]: https://brot74.atlassian.net/browse/BRT-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-113]: https://brot74.atlassian.net/browse/BRT-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ