### PR TITLE
fix(BRT-111): cancelación de pedido idempotente

### DIFF
--- a/app/api/admin/orders/[id]/route.ts
+++ b/app/api/admin/orders/[id]/route.ts
@@ -2,6 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAdmin } from "@/lib/auth";
 
+class InsufficientStockError extends Error {
+  constructor(public productId: number) {
+    super(`Stock insuficiente para reactivar el pedido (producto ${productId})`);
+  }
+}
+
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAdmin(req);
   if (!session) return NextResponse.json({ error: "No autorizado" }, { status: 401 });
@@ -14,20 +20,69 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json({ error: "Estado inválido" }, { status: 400 });
   }
 
-  const order = await prisma.order.update({
-    where: { id: parseInt(id) },
-    data: { status },
+  const orderId = parseInt(id);
+
+  const current = await prisma.order.findUnique({
+    where: { id: orderId },
     include: { items: true },
   });
 
-  // Release stock if cancelled
-  if (status === "cancelled") {
-    for (const item of order.items) {
-      await prisma.productStock.updateMany({
-        where: { productId: item.productId, deliverySlotId: order.deliverySlotId },
-        data: { reservedStock: { decrement: item.quantity } },
-      });
+  if (!current) {
+    return NextResponse.json({ error: "Pedido no encontrado" }, { status: 404 });
+  }
+
+  // BRT-111: el ajuste de stock solo debe ocurrir en la transición
+  // hacia/desde "cancelled", no cada vez que llega status: "cancelled" en
+  // el PATCH — cancelar dos veces el mismo pedido no debe liberar stock
+  // dos veces.
+  const wasCancelled = current.status === "cancelled";
+  const willBeCancelled = status === "cancelled";
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.order.update({ where: { id: orderId }, data: { status } });
+
+      if (willBeCancelled && !wasCancelled) {
+        // Cancelando por primera vez: liberar el stock reservado.
+        for (const item of current.items) {
+          await tx.productStock.updateMany({
+            where: { productId: item.productId, deliverySlotId: current.deliverySlotId },
+            data: { reservedStock: { decrement: item.quantity } },
+          });
+        }
+      } else if (!willBeCancelled && wasCancelled) {
+        // Reactivando un pedido cancelado: volver a reservar el stock,
+        // de forma atómica y solo si hay capacidad disponible en este
+        // momento (mismo patrón que BRT-109 en /api/orders). Orden
+        // consistente por productId para evitar deadlocks con otras
+        // transacciones concurrentes.
+        const sortedItems = [...current.items].sort((a, b) => a.productId - b.productId);
+
+        for (const item of sortedItems) {
+          const affected = await tx.$executeRaw`
+            UPDATE "ProductStock"
+            SET "reservedStock" = "reservedStock" + ${item.quantity}
+            WHERE "productId" = ${item.productId}
+              AND "deliverySlotId" = ${current.deliverySlotId}
+              AND "totalStock" - "reservedStock" >= ${item.quantity}
+          `;
+
+          if (affected === 0) {
+            throw new InsufficientStockError(item.productId);
+          }
+        }
+      }
+      // Si willBeCancelled === wasCancelled (incluye "cancelar" un pedido
+      // ya cancelado), no se toca el stock: la operación es idempotente.
+    });
+  } catch (e) {
+    if (e instanceof InsufficientStockError) {
+      return NextResponse.json(
+        { error: "No hay stock suficiente para reactivar este pedido" },
+        { status: 409 }
+      );
     }
+    throw e;
   }
 
   return NextResponse.json({ ok: true });

--- a/app/api/admin/orders/[id]/route.ts
+++ b/app/api/admin/orders/[id]/route.ts
@@ -8,6 +8,8 @@ class InsufficientStockError extends Error {
   }
 }
 
+class OrderNotFoundError extends Error {}
+
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAdmin(req);
   if (!session) return NextResponse.json({ error: "No autorizado" }, { status: 401 });
@@ -31,15 +33,23 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json({ error: "Pedido no encontrado" }, { status: 404 });
   }
 
-  // BRT-111: el ajuste de stock solo debe ocurrir en la transición
-  // hacia/desde "cancelled", no cada vez que llega status: "cancelled" en
-  // el PATCH — cancelar dos veces el mismo pedido no debe liberar stock
-  // dos veces.
-  const wasCancelled = current.status === "cancelled";
   const willBeCancelled = status === "cancelled";
 
   try {
     await prisma.$transaction(async (tx) => {
+      // Lock de fila + lectura del estado actual DENTRO de la transacción:
+      // si se leyera antes (como en la versión anterior), dos PATCH
+      // concurrentes sobre el mismo pedido podrían ver el mismo status
+      // "viejo" y decrementar/re-reservar stock cada uno por su cuenta —
+      // el SELECT ... FOR UPDATE serializa esas transiciones (mismo tipo
+      // de race que BRT-109 evitaba en ProductStock).
+      const [row] = await tx.$queryRaw<{ status: string }[]>`
+        SELECT status FROM "Order" WHERE id = ${orderId} FOR UPDATE
+      `;
+      if (!row) throw new OrderNotFoundError();
+
+      const wasCancelled = row.status === "cancelled";
+
       await tx.order.update({ where: { id: orderId }, data: { status } });
 
       if (willBeCancelled && !wasCancelled) {
@@ -76,6 +86,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       // ya cancelado), no se toca el stock: la operación es idempotente.
     });
   } catch (e) {
+    if (e instanceof OrderNotFoundError) {
+      return NextResponse.json({ error: "Pedido no encontrado" }, { status: 404 });
+    }
     if (e instanceof InsufficientStockError) {
       return NextResponse.json(
         { error: "No hay stock suficiente para reactivar este pedido" },

--- a/tests/integration/admin-orders.test.ts
+++ b/tests/integration/admin-orders.test.ts
@@ -169,4 +169,51 @@ describe("PATCH /api/admin/orders/[id]", () => {
     });
     expect(stock?.reservedStock).toBe(3);
   });
+
+  it("no libera stock dos veces con dos cancelaciones concurrentes del mismo pedido (BRT-111)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 3 });
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }]);
+
+    const headers = await adminCookieHeader();
+    const [resA, resB] = await Promise.all([
+      PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
+      PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
+    ]);
+
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    // Si el lock de fila no serializara las dos transacciones, esto
+    // quedaría en -3 (decrementado dos veces).
+    expect(stock?.reservedStock).toBe(0);
+  });
+
+  it("no re-reserva stock dos veces con dos reactivaciones concurrentes del mismo pedido (BRT-111)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 0 });
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
+      status: "cancelled",
+    });
+
+    const headers = await adminCookieHeader();
+    const [resA, resB] = await Promise.all([
+      PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
+      PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
+    ]);
+
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    // Si no serializara, quedaría en 6 (reservado dos veces).
+    expect(stock?.reservedStock).toBe(3);
+  });
 });

--- a/tests/integration/admin-orders.test.ts
+++ b/tests/integration/admin-orders.test.ts
@@ -96,4 +96,77 @@ describe("PATCH /api/admin/orders/[id]", () => {
     });
     expect(stock?.reservedStock).toBe(0);
   });
+
+  it("devuelve 404 si el pedido no existe", async () => {
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "paid" }, headers), { params: Promise.resolve({ id: "999999" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("no libera stock una segunda vez si el pedido ya estaba cancelado (BRT-111)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 3 });
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
+      status: "cancelled",
+    });
+    // El pedido ya estaba cancelado (y su stock ya liberado) antes de este
+    // test — simula que la reservedStock ya bajó a 0 en la cancelación
+    // original.
+    await prisma.productStock.update({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+      data: { reservedStock: 0 },
+    });
+
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
+
+    expect(res.status).toBe(200);
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    // Si se hubiera decrementado de nuevo, quedaría en -3.
+    expect(stock?.reservedStock).toBe(0);
+  });
+
+  it("vuelve a reservar el stock al reactivar un pedido cancelado, si hay disponible (BRT-111)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 0 });
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
+      status: "cancelled",
+    });
+
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
+
+    expect(res.status).toBe(200);
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    expect(stock?.reservedStock).toBe(3);
+  });
+
+  it("devuelve 409 y no reactiva el pedido si ya no hay stock disponible (BRT-111)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    // Ya no queda capacidad: todo el stock está comprometido por otro pedido.
+    await createProductStock(product.id, slot.id, { totalStock: 3, reservedStock: 3 });
+    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
+      status: "cancelled",
+    });
+
+    const headers = await adminCookieHeader();
+    const res = await PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
+
+    expect(res.status).toBe(409);
+
+    const updated = await prisma.order.findUnique({ where: { id: order.id } });
+    expect(updated?.status).toBe("cancelled");
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
+    });
+    expect(stock?.reservedStock).toBe(3);
+  });
 });


### PR DESCRIPTION
## Ticket
[BRT-111](https://brot74.atlassian.net/browse/BRT-111)

## Qué cambia
`admin/orders/[id]/route.ts` decrementaba `reservedStock` cada vez que llegaba `status: "cancelled"`, sin comparar contra el estado anterior — cancelar el mismo pedido dos veces liberaba stock fantasma. En sentido inverso, reactivar un pedido cancelado no volvía a reservar el stock.

- El ajuste de stock ahora depende de la **transición** real: decrementa solo al entrar a `cancelled` desde otro estado, y vuelve a reservar solo al salir de `cancelled`. Cualquier otro caso (incluido cancelar dos veces) no toca el stock.
- Reactivar un pedido usa el mismo patrón atómico de BRT-109 (update condicional + orden por `productId` contra deadlocks): sin stock disponible, la transacción aborta con 409 y el pedido queda como estaba.
- De yapa: 404 explícito si el pedido no existe.

## Verificación
- Tests nuevos: no libera dos veces al cancelar dos veces, re-reserva al reactivar con stock disponible, 409 sin stock disponible, 404 en pedido inexistente.
- `npm test` → 103/103 OK
- `npm run lint` → 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-111]: https://brot74.atlassian.net/browse/BRT-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Order status changes now automatically manage reserved inventory.
  - Reactivating a cancelled order restores reservations when sufficient stock is available.
  - Returns a conflict response when reactivation cannot be fulfilled due to insufficient stock.

- **Bug Fixes**
  - Prevents inventory from being released repeatedly when an order is cancelled more than once.
  - Keeps orders cancelled and inventory unchanged when reactivation fails.
  - Returns a not-found response for nonexistent orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->