### PR TITLE
fix(BRT-115): /api/cron/cleanup falla cerrado si falta CRON_SECRET

### DIFF
--- a/app/api/cron/cleanup/route.ts
+++ b/app/api/cron/cleanup/route.ts
@@ -2,12 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 
 export async function GET(req: NextRequest) {
+  // BRT-115: fail-closed. Si CRON_SECRET no está configurado, el endpoint
+  // se rechaza en vez de quedar abierto sin autenticación — antes, la
+  // ausencia de la env var salteaba el chequeo por completo.
   const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const auth = req.headers.get("authorization");
-    if (auth !== `Bearer ${secret}`) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  if (!secret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const auth = req.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { count } = await prisma.cartReservation.deleteMany({

--- a/tests/integration/cron-cleanup.test.ts
+++ b/tests/integration/cron-cleanup.test.ts
@@ -17,13 +17,13 @@ afterEach(() => {
 
 describe("GET /api/cron/cleanup", () => {
   it("borra solo las reservas de carrito expiradas", async () => {
-    delete process.env.CRON_SECRET;
+    process.env.CRON_SECRET = "mi-secreto";
     const product = await createProduct();
     const slot = await createDeliverySlot();
     await createCartReservation(product.id, slot.id, { expiresAt: new Date(Date.now() - 60_000) });
     const active = await createCartReservation(product.id, slot.id, { expiresAt: new Date(Date.now() + 60_000) });
 
-    const res = await GET(getRequest());
+    const res = await GET(getRequest({ authorization: "Bearer mi-secreto" }));
     const json = await res.json();
 
     expect(res.status).toBe(200);
@@ -33,11 +33,14 @@ describe("GET /api/cron/cleanup", () => {
     expect(remaining.map((r) => r.id)).toEqual([active.id]);
   });
 
-  it("sin CRON_SECRET configurado, no exige autorización", async () => {
+  it("sin CRON_SECRET configurado, rechaza el request en vez de dejarlo abierto (BRT-115)", async () => {
     delete process.env.CRON_SECRET;
 
     const res = await GET(getRequest());
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
+
+    const resWithHeader = await GET(getRequest({ authorization: "Bearer lo-que-sea" }));
+    expect(resWithHeader.status).toBe(401);
   });
 
   it("con CRON_SECRET configurado, devuelve 401 sin el header correcto", async () => {


### PR DESCRIPTION
## Ticket
[BRT-115](https://brot74.atlassian.net/browse/BRT-115)

## Qué cambia
El chequeo de autorización solo corría dentro de `if (secret)` — si `CRON_SECRET` no estaba configurada, el endpoint quedaba abierto sin autenticación (fail-open). Ahora rechaza con 401 si la env var no está seteada, en vez de saltear el chequeo por completo (fail-closed).

⚠️ Nota operativa: en Vercel, los Cron Jobs mandan automáticamente el header `Authorization: Bearer $CRON_SECRET` cuando esa env var está configurada en el proyecto — no hace falta ningún cambio de config para que el cron real siga funcionando, **siempre que `CRON_SECRET` ya esté seteada en producción**. Vale la pena confirmarlo en Vercel antes de dar por cerrado.

## Verificación
- Había un test que verificaba explícitamente el comportamiento viejo (sin `CRON_SECRET` → 200) — se reemplazó por el comportamiento correcto (401).
- `npm test` → 105/105 OK
- `npm run lint` → 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-115]: https://brot74.atlassian.net/browse/BRT-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ