### PR TITLE
fix(BRT-114): validar orderCutoff server-side al confirmar un pedido

### DIFF
--- a/app/api/delivery-slots/route.ts
+++ b/app/api/delivery-slots/route.ts
@@ -1,13 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-
-const CUTOFF_HOURS = 20;
-
-function isCutoffPassed(slot: { date: Date; orderCutoff: Date | null }, now: Date): boolean {
-  if (slot.orderCutoff) return now >= slot.orderCutoff;
-  const cutoff = new Date(slot.date.getTime() - CUTOFF_HOURS * 60 * 60 * 1000);
-  return now >= cutoff;
-}
+import { isCutoffPassed } from "@/lib/deliverySlots";
 
 export async function GET() {
   const now = new Date();

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -108,6 +108,17 @@ export async function POST(req: NextRequest) {
       enrichedItems.push({ productId: item.productId, quantity: item.quantity, unitPrice: product.price, name: product.name });
     }
 
+    // Re-chequeo del cutoff justo antes de crear el pedido: entre el chequeo
+    // de arriba y acá pasaron varias consultas async (productos, stock,
+    // reserva) — una ventana chica pero real en la que el cutoff podría
+    // haber pasado mientras se procesaba el request.
+    if (isCutoffPassed(slot, new Date())) {
+      return NextResponse.json(
+        { error: "El horario límite para pedir en esta fecha ya pasó" },
+        { status: 400 }
+      );
+    }
+
     // Create order, reserve stock, and release cart reservation — all in one transaction
     let order;
     try {

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { sendWhatsAppNotification, buildOrderMessage } from "@/lib/whatsapp";
 import { normalizeCartItems } from "@/lib/cartItems";
+import { isCutoffPassed } from "@/lib/deliverySlots";
 
 class InsufficientStockError extends Error {
   constructor(public productId: number, public productName: string) {
@@ -28,8 +29,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Fecha no disponible" }, { status: 400 });
     }
 
-    // Validate cart reservation if sessionToken provided
     const now = new Date();
+
+    // BRT-114: el cierre de pedidos por horario era solo cosmético en el
+    // front (/api/delivery-slots ocultaba la fecha vencida del listado,
+    // pero nada impedía confirmar el pedido igual pegándole directo al
+    // endpoint). Misma regla que usa /api/delivery-slots.
+    if (isCutoffPassed(slot, now)) {
+      return NextResponse.json(
+        { error: "El horario límite para pedir en esta fecha ya pasó" },
+        { status: 400 }
+      );
+    }
+
+    // Validate cart reservation if sessionToken provided
     let reservationValid = false;
     if (sessionToken) {
       // BRT-110: filtrar también por deliverySlotId — si no, una reserva de

--- a/lib/deliverySlots.ts
+++ b/lib/deliverySlots.ts
@@ -1,0 +1,17 @@
+/**
+ * Lógica de cutoff de pedidos, compartida entre /api/delivery-slots (para
+ * ocultar fechas vencidas del listado público) y /api/orders (BRT-114: la
+ * misma regla debe aplicarse server-side al confirmar un pedido, no solo
+ * para decidir qué se muestra en el front).
+ */
+
+export const CUTOFF_HOURS = 20;
+
+export function isCutoffPassed(
+  slot: { date: Date; orderCutoff: Date | null },
+  now: Date
+): boolean {
+  if (slot.orderCutoff) return now >= slot.orderCutoff;
+  const cutoff = new Date(slot.date.getTime() - CUTOFF_HOURS * 60 * 60 * 1000);
+  return now >= cutoff;
+}

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -72,6 +72,44 @@ describe("POST /api/orders", () => {
     expect(res.status).toBe(400);
   });
 
+  it("devuelve 400 si ya pasó el horario límite calculado por defecto (BRT-114)", async () => {
+    const product = await createProduct();
+    // Entrega en 1 hora => el cutoff por defecto (20hs antes de la fecha)
+    // ya pasó hace 19hs.
+    const slot = await createDeliverySlot({ date: new Date(Date.now() + 60 * 60 * 1000) });
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    const res = await POST(
+      makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 400 si ya pasó un orderCutoff explícito, aunque la fecha de entrega sea futura (BRT-114)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot({ orderCutoff: new Date(Date.now() - 60_000) });
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    const res = await POST(
+      makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("crea el pedido normalmente si todavía no pasó el cutoff (BRT-114)", async () => {
+    const product = await createProduct();
+    const slot = await createDeliverySlot();
+    await createProductStock(product.id, slot.id, { totalStock: 5 });
+
+    const res = await POST(
+      makeRequest(baseOrder({ deliverySlotId: slot.id, items: [{ productId: product.id, quantity: 1 }] }))
+    );
+
+    expect(res.status).toBe(200);
+  });
+
   it("devuelve 400 si el stock es insuficiente", async () => {
     const product = await createProduct();
     const slot = await createDeliverySlot();


### PR DESCRIPTION
## Ticket
[BRT-114](https://brot74.atlassian.net/browse/BRT-114)

## Qué cambia
El cierre de pedidos por horario era solo cosmético: `/api/delivery-slots` usaba `orderCutoff` (explícito, o calculado 20hs antes de la fecha) para ocultar fechas vencidas del listado público, pero `/api/orders` nunca lo chequeaba — un pedido mandado directo al endpoint después del cutoff se aceptaba igual.

- `lib/deliverySlots.ts`: se extrae `isCutoffPassed()`/`CUTOFF_HOURS` (antes privado en `delivery-slots/route.ts`) para que ambos endpoints usen exactamente la misma regla, sin duplicarla.
- `/api/orders` ahora rechaza con 400 si el cutoff de la fecha ya pasó.

## Verificación
- Tests nuevos: 400 con cutoff por defecto vencido, 400 con `orderCutoff` explícito vencido (aunque la fecha de entrega sea futura), 200 si todavía no pasó.
- `npm test` → 108/108 OK
- `npm run lint` → 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-114]: https://brot74.atlassian.net/browse/BRT-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delivery availability now consistently reflects order cutoff times.
  - Expired delivery dates are automatically hidden from available options.

- **Bug Fixes**
  - Orders can no longer be placed after the delivery cutoff.
  - Orders with an explicitly defined cutoff are correctly rejected once that time has passed.
  - Customers receive a clear notification when the ordering deadline has expired.
  - Orders placed before the cutoff continue to be accepted normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->