### PR TITLE
chore: reducir el pill de "Pedidos abiertos" a solo la luz verde

### DIFF
--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -261,31 +261,6 @@ export default function DateSelector({ slots, onChange }: DateSelectorProps) {
                 style={{ background: "linear-gradient(180deg,rgba(14,35,60,.36) 0%,rgba(14,35,60,.04) 34%,rgba(14,35,60,.5) 100%)" }}
               />
 
-              {/* Badge estado — "Pedidos abiertos" reducido a la mínima
-                 expresión: solo la luz verde pulsando, sin pill ni texto
-                 (el glow del brot-pulse ya la hace legible sobre la foto).
-                 "Pedidos cerrados" sigue con el pill completo. */}
-              {isOpen ? (
-                <span
-                  className="absolute top-5 right-5 w-2.5 h-2.5 rounded-full brot-pulse"
-                  style={{ background: "#16C65A" }}
-                  aria-label="Pedidos abiertos"
-                  role="status"
-                />
-              ) : (
-                <span
-                  className="absolute top-4 right-4 flex items-center gap-[7px] text-navy font-bold text-[12px] tracking-[.02em] px-[14px] py-[7px] rounded-full whitespace-nowrap"
-                  style={{
-                    background: "rgba(248,243,234,.88)",
-                    backdropFilter: "blur(8px)",
-                    WebkitBackdropFilter: "blur(8px)",
-                    boxShadow: "0 4px 14px -6px rgba(0,0,0,.4)",
-                  }}
-                >
-                  Pedidos cerrados
-                </span>
-              )}
-
               {/* Fecha centrada */}
               <div
                 className="absolute inset-0 flex flex-col items-center justify-center text-center select-none"

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -261,21 +261,30 @@ export default function DateSelector({ slots, onChange }: DateSelectorProps) {
                 style={{ background: "linear-gradient(180deg,rgba(14,35,60,.36) 0%,rgba(14,35,60,.04) 34%,rgba(14,35,60,.5) 100%)" }}
               />
 
-              {/* Badge estado */}
-              <span
-                className="absolute top-4 right-4 flex items-center gap-[7px] text-navy font-bold text-[12px] tracking-[.02em] px-[14px] py-[7px] rounded-full whitespace-nowrap"
-                style={{
-                  background: "rgba(248,243,234,.88)",
-                  backdropFilter: "blur(8px)",
-                  WebkitBackdropFilter: "blur(8px)",
-                  boxShadow: "0 4px 14px -6px rgba(0,0,0,.4)",
-                }}
-              >
-                {isOpen && (
-                  <span className="w-2 h-2 rounded-full brot-pulse" style={{ background: "#16C65A" }} />
-                )}
-                {isOpen ? "Pedidos abiertos" : "Pedidos cerrados"}
-              </span>
+              {/* Badge estado — "Pedidos abiertos" reducido a la mínima
+                 expresión: solo la luz verde pulsando, sin pill ni texto
+                 (el glow del brot-pulse ya la hace legible sobre la foto).
+                 "Pedidos cerrados" sigue con el pill completo. */}
+              {isOpen ? (
+                <span
+                  className="absolute top-5 right-5 w-2.5 h-2.5 rounded-full brot-pulse"
+                  style={{ background: "#16C65A" }}
+                  aria-label="Pedidos abiertos"
+                  role="status"
+                />
+              ) : (
+                <span
+                  className="absolute top-4 right-4 flex items-center gap-[7px] text-navy font-bold text-[12px] tracking-[.02em] px-[14px] py-[7px] rounded-full whitespace-nowrap"
+                  style={{
+                    background: "rgba(248,243,234,.88)",
+                    backdropFilter: "blur(8px)",
+                    WebkitBackdropFilter: "blur(8px)",
+                    boxShadow: "0 4px 14px -6px rgba(0,0,0,.4)",
+                  }}
+                >
+                  Pedidos cerrados
+                </span>
+              )}
 
               {/* Fecha centrada */}
               <div


### PR DESCRIPTION
## Qué hace

En `DateSelector.tsx`, el badge de estado de la tarjeta de fecha:
- **"Pedidos abiertos"** → ya no es un pill con fondo/blur/texto, queda solo el punto verde pulsante (`brot-pulse`), sin cambio de tamaño de posición relevante (mismo lugar, esquina superior derecha de la foto).
- **"Pedidos cerrados"** → sin cambios, sigue con el pill completo.

## Verificado

- Visualmente en desktop y mobile (screenshot en ambos) — el punto se ve bien legible sobre la foto gracias al glow de la animación existente.
- `npm run build`/`lint`/`tsc` sin errores nuevos (24 warnings preexistentes en `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the “Pedidos abiertos” and “Pedidos cerrados” status badge from the date card media section.
  * Removed the associated open-state indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->