### PR TITLE
fix(BRT-119): error 500 al crear producto desde el admin

### DIFF
--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAdmin } from "@/lib/auth";
-
-const DAY_MAP: Record<string, number> = { lunes: 1, miercoles: 3, sabado: 6 };
-const DEFAULT_STOCK = 5;
+import { syncProductStockForDays } from "@/lib/productStock";
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAdmin(req);
@@ -14,8 +12,8 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   const data = await req.json();
 
   const prevProduct = await prisma.product.findUnique({ where: { id: productId } });
-  const prevDays = new Set((prevProduct?.availableDays ?? "").split(",").filter(Boolean));
-  const newDays = new Set((data.availableDays ?? "").split(",").filter(Boolean));
+  const prevDays = new Set<string>((prevProduct?.availableDays ?? "").split(",").filter(Boolean));
+  const newDays = new Set<string>(String(data.availableDays ?? "").split(",").filter(Boolean));
 
   const product = await prisma.product.update({
     where: { id: productId },
@@ -35,41 +33,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     },
   });
 
-  // Apply day changes to all future slots
-  const now = new Date();
-  now.setHours(0, 0, 0, 0);
-  const futureSlots = await prisma.deliverySlot.findMany({ where: { date: { gte: now } } });
-
-  for (const slot of futureSlots) {
-    const slotDay = new Date(slot.date).getDay();
-    const dayName = Object.entries(DAY_MAP).find(([, v]) => v === slotDay)?.[0];
-    if (!dayName) continue;
-
-    const wasAvailable = prevDays.has(dayName);
-    const isAvailable = newDays.has(dayName);
-
-    if (wasAvailable === isAvailable) continue; // no change for this day
-
-    const existing = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId, deliverySlotId: slot.id } },
-    });
-
-    if (isAvailable && !wasAvailable) {
-      // Activar: si no existe o estaba en 0, poner stock por defecto
-      await prisma.productStock.upsert({
-        where: { productId_deliverySlotId: { productId, deliverySlotId: slot.id } },
-        update: existing?.totalStock === 0 ? { totalStock: DEFAULT_STOCK } : {},
-        create: { productId, deliverySlotId: slot.id, totalStock: DEFAULT_STOCK, reservedStock: 0 },
-      });
-    } else if (!isAvailable && wasAvailable) {
-      // Desactivar: poner stock en 0
-      await prisma.productStock.upsert({
-        where: { productId_deliverySlotId: { productId, deliverySlotId: slot.id } },
-        update: { totalStock: 0 },
-        create: { productId, deliverySlotId: slot.id, totalStock: 0, reservedStock: 0 },
-      });
-    }
-  }
+  await syncProductStockForDays(productId, prevDays, newDays);
 
   return NextResponse.json(product);
 }

--- a/app/api/admin/products/route.ts
+++ b/app/api/admin/products/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { requireAdmin } from "@/lib/auth";
+import { isIdConflict, resyncIdSequence } from "@/lib/idSequence";
+import { syncProductStockForDays } from "@/lib/productStock";
 
 export async function GET(req: NextRequest) {
   const session = await requireAdmin(req);
@@ -17,20 +20,35 @@ export async function POST(req: NextRequest) {
   if (!session) return NextResponse.json({ error: "No autorizado" }, { status: 401 });
 
   const data = await req.json();
-  const product = await prisma.product.create({
-    data: {
-      name: data.name,
-      description: data.description ?? "",
-      price: parseInt(data.price),
-      weight: data.weight ?? "",
-      ingredients: data.ingredients ?? "",
-      imageUrl: data.imageUrl ?? "",
-      focalX: data.focalX ?? 50,
-      focalY: data.focalY ?? 50,
-      imageScale: data.imageScale ?? 1,
-      active: data.active ?? true,
-      sortOrder: data.sortOrder ?? 0,
-    },
-  });
+  const productData: Prisma.ProductCreateInput = {
+    name: data.name,
+    description: data.description ?? "",
+    price: parseInt(data.price),
+    weight: data.weight ?? "",
+    ingredients: data.ingredients ?? "",
+    imageUrl: data.imageUrl ?? "",
+    focalX: data.focalX ?? 50,
+    focalY: data.focalY ?? 50,
+    imageScale: data.imageScale ?? 1,
+    availableDays: data.availableDays ?? "",
+    active: data.active ?? true,
+    sortOrder: data.sortOrder ?? 0,
+  };
+
+  let product;
+  try {
+    product = await prisma.product.create({ data: productData });
+  } catch (err) {
+    // La secuencia de "id" puede quedar desincronizada del MAX(id) real
+    // (prisma db push --accept-data-loss recreando la tabla, restores, etc.)
+    // y chocar con un id ya existente. Se resincroniza y se reintenta una vez.
+    if (!isIdConflict(err)) throw err;
+    await resyncIdSequence("Product");
+    product = await prisma.product.create({ data: productData });
+  }
+
+  const newDays = new Set<string>(String(data.availableDays ?? "").split(",").filter(Boolean));
+  await syncProductStockForDays(product.id, new Set(), newDays);
+
   return NextResponse.json(product, { status: 201 });
 }

--- a/lib/idSequence.ts
+++ b/lib/idSequence.ts
@@ -1,0 +1,29 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db";
+
+/**
+ * Resincroniza la secuencia autoincremental de `id` de una tabla con el
+ * MAX(id) real de sus filas.
+ *
+ * `prisma db push --accept-data-loss` corre en cada build de producción
+ * (ver BRT-112) y puede recrear una tabla sin preservar el estado de su
+ * secuencia si en algún momento hubo filas insertadas con `id` explícito
+ * (seed, restore, import). La secuencia queda por detrás del máximo real y
+ * la próxima inserción autoincremental choca con un id ya existente
+ * (Prisma P2002 en el campo "id"). Ver BRT-119.
+ */
+export async function resyncIdSequence(tableName: string) {
+  await prisma.$executeRawUnsafe(
+    `SELECT setval(pg_get_serial_sequence('"${tableName}"', 'id'), COALESCE((SELECT MAX(id) + 1 FROM "${tableName}"), 1), false)`
+  );
+}
+
+/** True si el error es un choque de unique constraint (P2002) sobre el campo "id". */
+export function isIdConflict(err: unknown): boolean {
+  return (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    err.code === "P2002" &&
+    Array.isArray(err.meta?.target) &&
+    (err.meta.target as string[]).includes("id")
+  );
+}

--- a/lib/productStock.ts
+++ b/lib/productStock.ts
@@ -1,0 +1,47 @@
+import { prisma } from "@/lib/db";
+
+const DAY_MAP: Record<string, number> = { lunes: 1, miercoles: 3, sabado: 6 };
+export const DEFAULT_STOCK = 5;
+
+/**
+ * Sincroniza el ProductStock de los slots futuros de un producto según el
+ * cambio de días disponibles (prevDays -> newDays): a los días que se agregan
+ * les pone stock por defecto (o lo restaura si estaba en 0), y a los días que
+ * se quitan les pone el stock en 0. No toca slots que ya pasaron ni días sin
+ * cambios. Usado tanto al crear un producto (prevDays vacío) como al editarlo.
+ */
+export async function syncProductStockForDays(productId: number, prevDays: Set<string>, newDays: Set<string>) {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const futureSlots = await prisma.deliverySlot.findMany({ where: { date: { gte: now } } });
+
+  for (const slot of futureSlots) {
+    const slotDay = new Date(slot.date).getDay();
+    const dayName = Object.entries(DAY_MAP).find(([, v]) => v === slotDay)?.[0];
+    if (!dayName) continue;
+
+    const wasAvailable = prevDays.has(dayName);
+    const isAvailable = newDays.has(dayName);
+    if (wasAvailable === isAvailable) continue; // no change for this day
+
+    const existing = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId, deliverySlotId: slot.id } },
+    });
+
+    if (isAvailable && !wasAvailable) {
+      // Activar: si no existe o estaba en 0, poner stock por defecto
+      await prisma.productStock.upsert({
+        where: { productId_deliverySlotId: { productId, deliverySlotId: slot.id } },
+        update: existing?.totalStock === 0 ? { totalStock: DEFAULT_STOCK } : {},
+        create: { productId, deliverySlotId: slot.id, totalStock: DEFAULT_STOCK, reservedStock: 0 },
+      });
+    } else if (!isAvailable && wasAvailable) {
+      // Desactivar: poner stock en 0
+      await prisma.productStock.upsert({
+        where: { productId_deliverySlotId: { productId, deliverySlotId: slot.id } },
+        update: { totalStock: 0 },
+        create: { productId, deliverySlotId: slot.id, totalStock: 0, reservedStock: 0 },
+      });
+    }
+  }
+}

--- a/tests/integration/admin-products.test.ts
+++ b/tests/integration/admin-products.test.ts
@@ -70,6 +70,46 @@ describe("POST /api/admin/products", () => {
     expect(json.active).toBe(true);
     expect(json.focalX).toBe(50);
   });
+
+  it("persiste availableDays (BRT-119)", async () => {
+    const res = await POST(
+      postRequest({ name: "Con días", price: "1500", availableDays: "lunes,sabado" }, await adminCookieHeader())
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.availableDays).toBe("lunes,sabado");
+  });
+
+  it("al crear con un día disponible, inicializa stock (5) en slots futuros de ese día (BRT-119)", async () => {
+    const mondaySlot = await createDeliverySlot({ date: nextMondayAt(24) });
+
+    const res = await POST(
+      postRequest({ name: "Con stock", price: "1500", availableDays: "lunes" }, await adminCookieHeader())
+    );
+    const json = await res.json();
+
+    const stock = await prisma.productStock.findUnique({
+      where: { productId_deliverySlotId: { productId: json.id, deliverySlotId: mondaySlot.id } },
+    });
+    expect(stock?.totalStock).toBe(5);
+  });
+
+  it("se recupera sola si la secuencia de id quedó desincronizada, en vez de devolver 500 (BRT-119)", async () => {
+    const existing = await createProduct({ name: "Ya existe" });
+    // Simula el drift real: la secuencia autoincremental quedó apuntando a un
+    // id que ya existe (prisma db push recreando la tabla, restore, etc.).
+    await prisma.$executeRawUnsafe(
+      `SELECT setval(pg_get_serial_sequence('"Product"', 'id'), ${existing.id}, false)`
+    );
+
+    const res = await POST(postRequest({ name: "Tras el drift", price: "1500" }, await adminCookieHeader()));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.name).toBe("Tras el drift");
+    expect(json.id).not.toBe(existing.id);
+  });
 });
 
 describe("PUT /api/admin/products/[id]", () => {


### PR DESCRIPTION
Fixes [BRT-119](https://brot74.atlassian.net/browse/BRT-119)

## Causa raíz del 500

La secuencia autoincremental de `Product.id` en producción quedó desincronizada del `MAX(id)` real de la tabla (el mismo tipo de drift que ya trackea [BRT-112](https://brot74.atlassian.net/browse/BRT-112) sobre `prisma db push --accept-data-loss` corriendo en cada build) — `prisma.product.create()` choca con un id ya existente (`P2002`). Reproducido localmente con el payload exacto reportado en el ticket.

## Qué cambia

- `lib/idSequence.ts`: si `product.create()` choca por conflicto de `id`, resincroniza la secuencia contra `MAX(id)+1` y reintenta una vez — la próxima creación se auto-cura sin intervención manual.
- `lib/productStock.ts`: extrae `syncProductStockForDays()` del `PUT` (antes solo el edit inicializaba `ProductStock` al activar un día).
- `POST /api/admin/products`:
  - Ahora persiste `availableDays` (antes se descartaba en silencio, el producto quedaba creado con `""`).
  - Inicializa `ProductStock` para los slots futuros que coincidan con los días elegidos — paridad con el `PUT`, un producto recién creado ya tiene stock disponible sin necesitar una edición extra.
- `PUT` queda con el mismo comportamiento de siempre, solo reusa el helper en vez de tener la lógica duplicada inline.

## Tests

Agregados en `tests/integration/admin-products.test.ts` (Postgres real, sin mocks):
- `POST` persiste `availableDays`.
- `POST` con un día disponible inicializa `ProductStock` (5) en los slots futuros de ese día.
- `POST` se recupera sola ante un drift de secuencia forzado a propósito (repro exacto del 500), en vez de devolver 500.

No pude correr el suite completo localmente (este sandbox no tiene Docker para levantar `docker-compose.test.yml`) — quedo atento al check `integration` de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-119]: https://brot74.atlassian.net/browse/BRT-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-112]: https://brot74.atlassian.net/browse/BRT-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ