### PR TITLE
chore: extraer helper getStock() en tests para bajar duplicación

### DIFF
--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -29,6 +29,12 @@ export async function createDeliverySlot(overrides: Partial<Prisma.DeliverySlotU
   });
 }
 
+export async function getStock(productId: number, deliverySlotId: number) {
+  return prisma.productStock.findUnique({
+    where: { productId_deliverySlotId: { productId, deliverySlotId } },
+  });
+}
+
 export async function createProductStock(
   productId: number,
   deliverySlotId: number,

--- a/tests/integration/admin-orders.test.ts
+++ b/tests/integration/admin-orders.test.ts
@@ -22,6 +22,14 @@ function patchRequest(body: unknown, headers: Record<string, string> = {}) {
   });
 }
 
+/** Dispara el mismo PATCH de status dos veces en simultáneo, para tests de concurrencia. */
+function patchTwiceConcurrently(orderId: number, status: string, headers: Record<string, string>) {
+  return Promise.all([
+    PATCH(patchRequest({ status }, headers), { params: Promise.resolve({ id: String(orderId) }) }),
+    PATCH(patchRequest({ status }, headers), { params: Promise.resolve({ id: String(orderId) }) }),
+  ]);
+}
+
 describe("GET /api/admin/orders", () => {
   it("devuelve 401 sin sesión de admin", async () => {
     const res = await GET(getRequest());
@@ -169,10 +177,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }]);
 
     const headers = await adminCookieHeader();
-    const [resA, resB] = await Promise.all([
-      PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
-      PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
-    ]);
+    const [resA, resB] = await patchTwiceConcurrently(order.id, "cancelled", headers);
 
     expect(resA.status).toBe(200);
     expect(resB.status).toBe(200);
@@ -192,10 +197,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     });
 
     const headers = await adminCookieHeader();
-    const [resA, resB] = await Promise.all([
-      PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
-      PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) }),
-    ]);
+    const [resA, resB] = await patchTwiceConcurrently(order.id, "pending", headers);
 
     expect(resA.status).toBe(200);
     expect(resB.status).toBe(200);

--- a/tests/integration/admin-orders.test.ts
+++ b/tests/integration/admin-orders.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 import { GET } from "@/app/api/admin/orders/route";
 import { PATCH } from "@/app/api/admin/orders/[id]/route";
 import { prisma } from "@/lib/db";
-import { createProduct, createDeliverySlot, createProductStock, createOrder } from "../helpers/factories";
+import { createProduct, createDeliverySlot, createProductStock, createOrder, getStock } from "../helpers/factories";
 import { adminCookieHeader } from "../helpers/auth";
 
 function getRequest(query = "") {
@@ -91,9 +91,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     const res = await PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
 
     expect(res.status).toBe(200);
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     expect(stock?.reservedStock).toBe(0);
   });
 
@@ -122,9 +120,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     const res = await PATCH(patchRequest({ status: "cancelled" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
 
     expect(res.status).toBe(200);
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     // Si se hubiera decrementado de nuevo, quedaría en -3.
     expect(stock?.reservedStock).toBe(0);
   });
@@ -141,9 +137,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     const res = await PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
 
     expect(res.status).toBe(200);
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     expect(stock?.reservedStock).toBe(3);
   });
 
@@ -164,9 +158,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     const updated = await prisma.order.findUnique({ where: { id: order.id } });
     expect(updated?.status).toBe("cancelled");
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     expect(stock?.reservedStock).toBe(3);
   });
 
@@ -185,9 +177,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     expect(resA.status).toBe(200);
     expect(resB.status).toBe(200);
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     // Si el lock de fila no serializara las dos transacciones, esto
     // quedaría en -3 (decrementado dos veces).
     expect(stock?.reservedStock).toBe(0);
@@ -210,9 +200,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
     expect(resA.status).toBe(200);
     expect(resB.status).toBe(200);
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     // Si no serializara, quedaría en 6 (reservado dos veces).
     expect(stock?.reservedStock).toBe(3);
   });

--- a/tests/integration/admin-orders.test.ts
+++ b/tests/integration/admin-orders.test.ts
@@ -30,6 +30,17 @@ function patchTwiceConcurrently(orderId: number, status: string, headers: Record
   ]);
 }
 
+/** Producto + slot con stock, y un pedido ya cancelado de 3 unidades — fixture de los tests de reactivación. */
+async function createCancelledOrderWithStock(totalStock: number) {
+  const product = await createProduct();
+  const slot = await createDeliverySlot();
+  await createProductStock(product.id, slot.id, { totalStock, reservedStock: 0 });
+  const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
+    status: "cancelled",
+  });
+  return { product, slot, order };
+}
+
 describe("GET /api/admin/orders", () => {
   it("devuelve 401 sin sesión de admin", async () => {
     const res = await GET(getRequest());
@@ -134,12 +145,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
   });
 
   it("vuelve a reservar el stock al reactivar un pedido cancelado, si hay disponible (BRT-111)", async () => {
-    const product = await createProduct();
-    const slot = await createDeliverySlot();
-    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 0 });
-    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
-      status: "cancelled",
-    });
+    const { product, slot, order } = await createCancelledOrderWithStock(10);
 
     const headers = await adminCookieHeader();
     const res = await PATCH(patchRequest({ status: "pending" }, headers), { params: Promise.resolve({ id: String(order.id) }) });
@@ -189,12 +195,7 @@ describe("PATCH /api/admin/orders/[id]", () => {
   });
 
   it("no re-reserva stock dos veces con dos reactivaciones concurrentes del mismo pedido (BRT-111)", async () => {
-    const product = await createProduct();
-    const slot = await createDeliverySlot();
-    await createProductStock(product.id, slot.id, { totalStock: 10, reservedStock: 0 });
-    const order = await createOrder(slot.id, [{ productId: product.id, quantity: 3, unitPrice: 1000 }], {
-      status: "cancelled",
-    });
+    const { product, slot, order } = await createCancelledOrderWithStock(10);
 
     const headers = await adminCookieHeader();
     const [resA, resB] = await patchTwiceConcurrently(order.id, "pending", headers);

--- a/tests/integration/admin-products.test.ts
+++ b/tests/integration/admin-products.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 import { GET, POST } from "@/app/api/admin/products/route";
 import { PUT, DELETE } from "@/app/api/admin/products/[id]/route";
 import { prisma } from "@/lib/db";
-import { createProduct, createDeliverySlot, createProductStock } from "../helpers/factories";
+import { createProduct, createDeliverySlot, createProductStock, getStock } from "../helpers/factories";
 import { adminCookieHeader } from "../helpers/auth";
 
 function getRequest(headers: Record<string, string> = {}) {
@@ -89,9 +89,7 @@ describe("POST /api/admin/products", () => {
     );
     const json = await res.json();
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: json.id, deliverySlotId: mondaySlot.id } },
-    });
+    const stock = await getStock(json.id, mondaySlot.id);
     expect(stock?.totalStock).toBe(5);
   });
 
@@ -140,9 +138,7 @@ describe("PUT /api/admin/products/[id]", () => {
       params: Promise.resolve({ id: String(product.id) }),
     });
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: mondaySlot.id } },
-    });
+    const stock = await getStock(product.id, mondaySlot.id);
     expect(stock?.totalStock).toBe(5);
   });
 
@@ -155,9 +151,7 @@ describe("PUT /api/admin/products/[id]", () => {
       params: Promise.resolve({ id: String(product.id) }),
     });
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: mondaySlot.id } },
-    });
+    const stock = await getStock(product.id, mondaySlot.id);
     expect(stock?.totalStock).toBe(0);
   });
 
@@ -169,9 +163,7 @@ describe("PUT /api/admin/products/[id]", () => {
       params: Promise.resolve({ id: String(product.id) }),
     });
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: pastMonday.id } },
-    });
+    const stock = await getStock(product.id, pastMonday.id);
     expect(stock).toBeNull();
   });
 
@@ -184,9 +176,7 @@ describe("PUT /api/admin/products/[id]", () => {
       params: Promise.resolve({ id: String(product.id) }),
     });
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: mondaySlot.id } },
-    });
+    const stock = await getStock(product.id, mondaySlot.id);
     expect(stock?.totalStock).toBe(8);
     expect(stock?.reservedStock).toBe(1);
   });

--- a/tests/integration/admin-stock.test.ts
+++ b/tests/integration/admin-stock.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
 import { GET, PUT } from "@/app/api/admin/stock/route";
-import { prisma } from "@/lib/db";
-import { createProduct, createDeliverySlot, createProductStock } from "../helpers/factories";
+import { createProduct, createDeliverySlot, createProductStock, getStock } from "../helpers/factories";
 import { adminCookieHeader } from "../helpers/auth";
 
 function getRequest(query = "", headers: Record<string, string> = {}) {
@@ -77,9 +76,7 @@ describe("PUT /api/admin/stock", () => {
 
     await PUT(putRequest({ productId: product.id, deliverySlotId: slot.id, totalStock: 20 }, await adminCookieHeader()));
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     expect(stock?.totalStock).toBe(20);
     expect(stock?.reservedStock).toBe(2);
   });

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -9,7 +9,7 @@ vi.mock("@/lib/whatsapp", () => ({
 import { POST } from "@/app/api/orders/route";
 import { sendWhatsAppNotification } from "@/lib/whatsapp";
 import { prisma } from "@/lib/db";
-import { createProduct, createDeliverySlot, createProductStock, createCartReservation } from "../helpers/factories";
+import { createProduct, createDeliverySlot, createProductStock, createCartReservation, getStock } from "../helpers/factories";
 
 function makeRequest(body: unknown) {
   return new NextRequest("http://localhost/api/orders", {
@@ -48,9 +48,7 @@ describe("POST /api/orders", () => {
     expect(res.status).toBe(200);
     expect(json.total).toBe(3000);
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     expect(stock?.reservedStock).toBe(2);
 
     const cartReservations = await prisma.cartReservation.findMany({ where: { sessionToken } });
@@ -205,9 +203,7 @@ describe("POST /api/orders", () => {
     const statuses = [resA.status, resB.status].sort();
     expect(statuses).toEqual([200, 409]);
 
-    const stock = await prisma.productStock.findUnique({
-      where: { productId_deliverySlotId: { productId: product.id, deliverySlotId: slot.id } },
-    });
+    const stock = await getStock(product.id, slot.id);
     expect(stock?.reservedStock).toBe(1);
 
     const orders = await prisma.order.findMany();


### PR DESCRIPTION
El commit `359caa4` (merge de BRT-112) hizo fallar el gate de SonarCloud en `main` por 4.4% de duplicación en código nuevo (máximo 3%) — no tiene relación con ese cambio, es duplicación preexistente en `tests/integration/**` que cruzó el umbral.

## Causa

El mismo bloque

```ts
const stock = await prisma.productStock.findUnique({
  where: { productId_deliverySlotId: { productId: X, deliverySlotId: Y } },
});
```

aparecía **14 veces** en 4 archivos (`admin-orders.test.ts`, `admin-products.test.ts`, `admin-stock.test.ts`, `orders.test.ts`).

## Qué cambia

Se extrae `getStock(productId, deliverySlotId)` a `tests/helpers/factories.ts` y se reemplazan las 14 ocurrencias. Sin cambios de comportamiento — es un refactor mecánico de tests.

## Cómo lo probé

`tsc --noEmit` y `eslint` limpios. No pude correr el suite completo local (sin Docker en este sandbox) — CI lo corre contra Postgres real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a shared test helper for retrieving product stock by product and delivery slot.
  - Updated order, product, and stock integration tests to use the shared helper while preserving existing coverage and stock-related assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->