### PR TITLE
feat(BRT-122): setup de Playwright para tests E2E

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,11 +93,13 @@ jobs:
 
       - run: npm ci
 
-      - run: npx prisma generate
+      # Binarios locales instalados por npm ci (versión fijada en package-lock.json),
+      # no npx — evita el riesgo de instalar/ejecutar algo on-demand desde CI.
+      - run: ./node_modules/.bin/prisma generate
 
-      - run: npx prisma migrate deploy
+      - run: ./node_modules/.bin/prisma migrate deploy
 
-      - run: npx playwright install --with-deps chromium
+      - run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - run: npm run test:e2e
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,49 @@ jobs:
       - run: npx prisma generate
 
       - run: npm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: brot74
+          POSTGRES_PASSWORD: brot74
+          POSTGRES_DB: brot74_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U brot74"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://brot74:brot74@localhost:5432/brot74_e2e
+      DIRECT_URL: postgresql://brot74:brot74@localhost:5432/brot74_e2e
+      ADMIN_PASSWORD: test-admin-password
+      JWT_SECRET: test-jwt-secret-not-for-production
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx prisma generate
+
+      - run: npx prisma migrate deploy
+
+      - run: npx playwright install --with-deps chromium
+
+      - run: npm run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,18 @@ next-env.d.ts
 # local Claude Code settings (may contain sensitive commands/history, machine-local)
 /.claude/settings.local.json
 
+# local Claude Code Browser-pane launch config (machine-local dev server config)
+/.claude/launch.json
+
 # design exports and raw screenshots (not source, kept out of the repo)
 /_design/
 /agent/
 /billeteras/
 /footer/
 /pantallas_brot74.pdf
+
+# Playwright (BRT-122)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,11 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 <!-- END:nextjs-agent-rules -->
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Sitio de e-commerce para [BROT74](https://brot74.com), panadería artesanal: cat
 - **[Vercel Blob](https://vercel.com/docs/storage/vercel-blob)** para imágenes de producto
 - Autenticación de admin con JWT ([`jose`](https://github.com/panva/jose)) en cookie `httpOnly`
 - **[Vitest](https://vitest.dev)** para tests de integración (API routes contra una base Postgres real)
+- **[Playwright](https://playwright.dev)** para tests E2E (flujo real en el navegador)
 - Deploy en **Vercel**, con un cron job (`/api/cron/cleanup`) para liberar reservas de carrito vencidas
 
 ## Funcionalidad
@@ -87,6 +88,17 @@ npm run test:db:down
 npm run db:seed
 ```
 
+### E2E (Playwright)
+
+Los tests E2E corren contra un servidor real (`npm run dev`, levantado automáticamente por Playwright) y necesitan las mismas variables de entorno que el dev server (`DATABASE_URL`, `ADMIN_PASSWORD`, `JWT_SECRET`, etc. — ver arriba).
+
+```bash
+npx playwright install --with-deps   # una sola vez
+npm run test:e2e
+```
+
+Los specs viven en `e2e/`. Todavía son solo el setup base (BRT-122) — los escenarios de negocio (checkout, reserva de stock, botón atrás, sesión de admin) se van sumando en tickets aparte.
+
 ## Scripts
 
 | Comando | Qué hace |
@@ -95,6 +107,7 @@ npm run db:seed
 | `npm run build` | `prisma generate` + `prisma migrate deploy` + build de Next |
 | `npm run lint` | ESLint |
 | `npm test` | Tests de integración (Vitest) |
+| `npm run test:e2e` | Tests E2E (Playwright) |
 | `npm run db:seed` | Carga datos de ejemplo |
 
 ## Licencia

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Smoke test de BRT-122: confirma que Playwright está bien cableado
+ * end-to-end (server + browser + CI) contra la home real de BROT74.
+ * Sin lógica de negocio todavía — eso lo cubren los tickets de E2E
+ * que dependen de este setup.
+ */
+test("la home carga y muestra el hero", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: /Pan de fermentación natural/i })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Reservá tu BROT/i })).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "sharp": "^0.35.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
         "@types/bcryptjs": "^3.0.0",
         "@types/cookie": "^1.0.0",
@@ -1820,6 +1821,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@prisma/client": {
@@ -7105,6 +7122,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:db:up": "docker compose -f docker-compose.test.yml up -d --wait",
-    "test:db:down": "docker compose -f docker-compose.test.yml down"
+    "test:db:down": "docker compose -f docker-compose.test.yml down",
+    "test:e2e": "playwright test"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"
@@ -34,6 +35,7 @@
     "sharp": "^0.35.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@types/bcryptjs": "^3.0.0",
     "@types/cookie": "^1.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Setup base de Playwright (BRT-122) — sin escenarios de negocio todavía,
+ * eso es alcance de los tickets de E2E que dependen de este (checkout,
+ * reserva de stock, botón atrás, sesión de admin).
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "list",
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     testTimeout: 15000,
     hookTimeout: 30000,
     fileParallelism: false,
+    // e2e/ son specs de Playwright (BRT-122), no de Vitest — sin este exclude,
+    // el glob default de Vitest los agarra igual y choca con el test() global
+    // de Playwright ("Playwright Test did not expect test() to be called here").
+    exclude: ["**/node_modules/**", "e2e/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Qué hace

Setup base de Playwright, prerequisito de los tickets de E2E (checkout, reserva de stock, botón atrás, sesión de admin) — [BRT-122](https://brot74.atlassian.net/browse/BRT-122).

- `playwright.config.ts` — chromium, `webServer` levanta `npm run dev` automáticamente.
- `e2e/home.spec.ts` — smoke test: confirma que la home carga y el hero se ve. Sin lógica de negocio todavía, eso es alcance de tickets aparte.
- `npm run test:e2e` — nuevo script.
- Job `e2e` nuevo en `.github/workflows/test.yml`, mismo patrón que el job `integration` existente (Postgres de servicio + `prisma migrate deploy`), sube el reporte HTML como artifact.
- README: sección de E2E + script en la tabla de scripts.

## Cómo se probó

- `npm run lint` → 0 errores (solo warnings preexistentes, ninguno en los archivos nuevos).
- `npx playwright test` local, contra `npm run dev` real → verde. De hecho encontró un mismatch real: el test esperaba el texto viejo del botón del hero ("Pedí tu BROT"), pero hoy dice "Reservá tu BROT →" — ajustado al texto actual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-122]: https://brot74.atlassian.net/browse/BRT-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end testing with Playwright, including a smoke test for the home page.
  * Added a command to run E2E tests locally.
  * Added automated E2E test execution in CI with Chromium and a PostgreSQL test database.
  * Test reports are uploaded when CI runs fail or are canceled.

* **Documentation**
  * Added setup and usage instructions for Playwright E2E testing, including required environment variables.

* **Tests**
  * Updated test configuration to keep E2E tests separate from unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->