### PR TITLE
feat(BRT-130): reestructurar layout base del home en secciones

### DIFF
--- a/app/confirmacion/page.tsx
+++ b/app/confirmacion/page.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import Link from "next/link";
+import BrotWordmark from "@/components/BrotWordmark";
 
 function WheatIcon() {
   return (
@@ -58,32 +59,7 @@ function ConfirmacionContent() {
             <circle cx="50" cy="50" r="48" fill="none" stroke="#F9F5EC" strokeWidth="0.7" opacity="0.85" />
             <circle cx="50" cy="50" r="43.6" fill="none" stroke="#F9F5EC" strokeWidth="0.32" opacity="0.45" />
           </svg>
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              paddingBottom: ".05em",
-            }}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/ramillete-mono-cream.png" alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
-            <div
-              style={{
-                display: "inline-flex",
-                alignItems: "baseline",
-                lineHeight: 1,
-                marginTop: ".01em",
-                fontFamily: "var(--font-jost, 'Jost', sans-serif)",
-              }}
-            >
-              <span style={{ fontWeight: 500, fontSize: ".115em", color: "#F9F5EC" }}>BROT</span>
-              <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
-            </div>
-          </div>
+          <BrotWordmark variant="cream" />
         </div>
 
         {/* Título */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ import ProductModal from "@/components/ProductModal";
 import OrderModal from "@/components/OrderModal";
 import CartBar from "@/components/CartBar";
 import DateSelector from "@/components/DateSelector";
+import HomeHero from "@/components/home/HomeHero";
+import HomeFooter from "@/components/home/HomeFooter";
 
 interface Slot {
   id: number | null;
@@ -38,10 +40,6 @@ interface Product {
 }
 
 type CartMap = Record<number, number>;
-
-const serif = "var(--font-hanken, 'Hanken Grotesk', system-ui, sans-serif)";
-
-const ctaTransition = "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s";
 
 // BRT-95: cada paso navegable del flujo se refleja en la URL vía query
 // params — la URL manda, el estado de "en qué paso estoy" se deriva de ella
@@ -468,181 +466,14 @@ function HomeContent() {
   }
 
   /* ─── HOME VIEW ──────────────────────────────────────────── */
+  // BRT-130: stack de secciones apilables. Hoy solo Hero + Footer (visual
+  // idéntico al home anterior); las secciones de BRT-131 a BRT-135
+  // (historia, ingredientes, showcase, cómo funciona, pedidos) se agregan
+  // acá en el medio, cada una como su propio componente en components/home/.
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
-
-        {/* ── Hero (v30: banda crema, antes navy) ── */}
-        <section
-          className="brot-hero-section flex flex-col items-center text-center"
-          style={{
-            background: "radial-gradient(120% 60% at 50% 22%, rgba(200,133,26,.10), rgba(14,35,60,0) 60%), #F9F5EC",
-            minHeight: "100svh",
-            padding: "64px 40px 40px",
-            position: "relative",
-            justifyContent: "center",
-          }}
-        >
-          {/* Grano sutil — le da algo de textura "hecho a mano" al fondo
-             crema, que si no queda un poco plano/corporativo. Puramente
-             CSS (SVG inline), no suma ningún asset nuevo. */}
-          <div
-            aria-hidden="true"
-            style={{
-              position: "absolute",
-              inset: 0,
-              backgroundImage:
-                "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
-              opacity: 0.035,
-              mixBlendMode: "multiply",
-              pointerEvents: "none",
-            }}
-          />
-
-          {/* Sello — v30: ramillete navy sobre crema (antes crema sobre navy) */}
-          <div
-            className="brot-hero-seal-wrap"
-            style={{
-              position: "relative",
-              width: "230px",
-              height: "230px",
-              fontSize: "230px",
-              flexShrink: 0,
-              filter: "drop-shadow(0 20px 36px rgba(0,0,0,.35))",
-            }}
-          >
-            <svg
-              style={{ position: "absolute", inset: 0, width: "100%", height: "100%", overflow: "visible" }}
-              viewBox="0 0 100 100"
-              aria-hidden="true"
-            >
-              <circle cx="50" cy="50" r="48" fill="none" stroke="#0E233C" strokeWidth="1" opacity="0.95" />
-              <circle cx="50" cy="50" r="43.6" fill="none" stroke="#0E233C" strokeWidth="0.5" opacity="0.6" />
-            </svg>
-            <div
-              style={{
-                position: "absolute",
-                inset: 0,
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                paddingBottom: ".05em",
-              }}
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/ramillete-mono-navy.png" alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
-              <div
-                style={{
-                  display: "inline-flex",
-                  alignItems: "baseline",
-                  lineHeight: 1,
-                  marginTop: ".01em",
-                  fontFamily: "var(--font-jost, 'Jost', sans-serif)",
-                }}
-              >
-                <span style={{ fontWeight: 500, fontSize: ".115em", color: "#0E233C" }}>BROT</span>
-                <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Kicker */}
-          <p className="brot-hero-kicker" style={{ marginTop: "48px" }}>
-            Micropanadería de masa madre
-          </p>
-
-          {/* Título */}
-          <h1
-            className="brot-hero-h1"
-            style={{
-              fontFamily: serif,
-              fontWeight: 800,
-              fontSize: "clamp(40px, 7.5vw, 60px)",
-              lineHeight: 1.08,
-              letterSpacing: "-.015em",
-              color: "#0E233C",
-              margin: "26px 0 0",
-              maxWidth: "13ch",
-              textWrap: "balance" as React.CSSProperties["textWrap"],
-            }}
-          >
-            Pan de fermentación natural,{" "}
-            <em style={{ fontStyle: "normal", color: "#C8851A" }}>como debe ser.</em>
-          </h1>
-
-          {/* CTA */}
-          <button
-            onClick={() => router.push(buildFlowUrl({ step: "slots" }))}
-            className="brot-hero-cta inline-flex items-center gap-[11px] font-bold border-none cursor-pointer"
-            style={{
-              marginTop: "44px",
-              fontSize: "16px",
-              letterSpacing: ".01em",
-              color: "#0E233C",
-              background: "#C8851A",
-              padding: "18px 30px",
-              borderRadius: "12px",
-              boxShadow: "0 16px 34px -14px rgba(200,133,26,.7)",
-              transition: ctaTransition,
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.transform = "translateY(-2px)";
-              e.currentTarget.style.background = "#E0A33A";
-              e.currentTarget.style.boxShadow = "0 20px 40px -14px rgba(200,133,26,.85)";
-              const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
-              if (arrow) arrow.style.transform = "translateX(4px)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.transform = "";
-              e.currentTarget.style.background = "#C8851A";
-              e.currentTarget.style.boxShadow = "0 16px 34px -14px rgba(200,133,26,.7)";
-              const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
-              if (arrow) arrow.style.transform = "";
-            }}
-            onMouseDown={(e) => { e.currentTarget.style.transform = "translateY(-2px) scale(.97)"; }}
-            onMouseUp={(e) => { e.currentTarget.style.transform = "translateY(-2px)"; }}
-            onTouchStart={(e) => { e.currentTarget.style.transform = "scale(.97)"; }}
-            onTouchEnd={(e) => { e.currentTarget.style.transform = ""; }}
-          >
-            Reservá tu BROT{" "}
-            <span className="arrow" style={{ fontSize: "17px", display: "inline-block", transition: "transform .2s cubic-bezier(.2,.7,.3,1)" }}>{"→"}</span>
-          </button>
-
-        </section>
-
-        {/* Footer: crédito de desarrollo */}
-        <footer
-          style={{
-            background: "#0E233C",
-            borderTop: "1px solid rgba(249,245,236,.08)",
-            padding: "14px 24px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "10px",
-          }}
-        >
-          <span
-            style={{
-              fontWeight: 600,
-              fontSize: "10.5px",
-              letterSpacing: ".08em",
-              textTransform: "uppercase",
-              color: "rgba(249,245,236,.42)",
-            }}
-          >
-            Powered by
-          </span>
-          <a href="https://luontek.com/" target="_blank" rel="noopener noreferrer">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="/luontek-horizontal-oscuro.svg"
-              alt="Luontek"
-              style={{ height: "18px", width: "auto", display: "block" }}
-            />
-          </a>
-        </footer>
-
+      <HomeHero onReservar={() => router.push(buildFlowUrl({ step: "slots" }))} />
+      <HomeFooter />
     </div>
   );
 }

--- a/components/BrotWordmark.tsx
+++ b/components/BrotWordmark.tsx
@@ -1,0 +1,43 @@
+interface BrotWordmarkProps {
+  /** navy: texto navy sobre fondo crema (hero). cream: texto crema sobre fondo navy (confirmación). */
+  variant: "navy" | "cream";
+}
+
+// BRT-130: el bloque de imagen + wordmark "BROT74" del sello se repetía
+// entre el hero del home y app/confirmacion/page.tsx (mismos colores
+// invertidos) — ya estaba duplicado antes, pero SonarCloud recién lo marcó
+// como código nuevo duplicado al mover el hero a su propio archivo
+// (components/home/HomeHero.tsx). Se centraliza acá.
+export default function BrotWordmark({ variant }: BrotWordmarkProps) {
+  const textColor = variant === "navy" ? "#0E233C" : "#F9F5EC";
+  const imgSrc = variant === "navy" ? "/ramillete-mono-navy.png" : "/ramillete-mono-cream.png";
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        paddingBottom: ".05em",
+      }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={imgSrc} alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
+      <div
+        style={{
+          display: "inline-flex",
+          alignItems: "baseline",
+          lineHeight: 1,
+          marginTop: ".01em",
+          fontFamily: "var(--font-jost, 'Jost', sans-serif)",
+        }}
+      >
+        <span style={{ fontWeight: 500, fontSize: ".115em", color: textColor }}>BROT</span>
+        <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
+      </div>
+    </div>
+  );
+}

--- a/components/home/HomeFooter.tsx
+++ b/components/home/HomeFooter.tsx
@@ -1,0 +1,38 @@
+// BRT-130: footer del home, extraído tal cual del render de HomeContent.
+// Va siempre al final del stack de secciones, después de la sección de
+// Pedidos (BRT-135).
+export default function HomeFooter() {
+  return (
+    <footer
+      style={{
+        background: "#0E233C",
+        borderTop: "1px solid rgba(249,245,236,.08)",
+        padding: "14px 24px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "10px",
+      }}
+    >
+      <span
+        style={{
+          fontWeight: 600,
+          fontSize: "10.5px",
+          letterSpacing: ".08em",
+          textTransform: "uppercase",
+          color: "rgba(249,245,236,.42)",
+        }}
+      >
+        Powered by
+      </span>
+      <a href="https://luontek.com/" target="_blank" rel="noopener noreferrer">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src="/luontek-horizontal-oscuro.svg"
+          alt="Luontek"
+          style={{ height: "18px", width: "auto", display: "block" }}
+        />
+      </a>
+    </footer>
+  );
+}

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+interface HomeHeroProps {
+  onReservar: () => void;
+}
+
+const serif = "var(--font-hanken, 'Hanken Grotesk', system-ui, sans-serif)";
+
+const ctaTransition = "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s";
+
+// BRT-130: primer bloque del home. Extraído tal cual del render de
+// HomeContent (antes era la vista "home" entera) para que el stack de
+// secciones nuevas (historia, ingredientes, showcase, cómo funciona,
+// pedidos — BRT-131 a BRT-135) pueda crecer alrededor sin que este
+// componente tenga que cambiar.
+export default function HomeHero({ onReservar }: HomeHeroProps) {
+  return (
+    <section
+      className="brot-hero-section flex flex-col items-center text-center"
+      style={{
+        background: "radial-gradient(120% 60% at 50% 22%, rgba(200,133,26,.10), rgba(14,35,60,0) 60%), #F9F5EC",
+        minHeight: "100svh",
+        padding: "64px 40px 40px",
+        position: "relative",
+        justifyContent: "center",
+      }}
+    >
+      {/* Grano sutil — le da algo de textura "hecho a mano" al fondo
+         crema, que si no queda un poco plano/corporativo. Puramente
+         CSS (SVG inline), no suma ningún asset nuevo. */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+          opacity: 0.035,
+          mixBlendMode: "multiply",
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* Sello — v30: ramillete navy sobre crema (antes crema sobre navy) */}
+      <div
+        className="brot-hero-seal-wrap"
+        style={{
+          position: "relative",
+          width: "230px",
+          height: "230px",
+          fontSize: "230px",
+          flexShrink: 0,
+          filter: "drop-shadow(0 20px 36px rgba(0,0,0,.35))",
+        }}
+      >
+        <svg
+          style={{ position: "absolute", inset: 0, width: "100%", height: "100%", overflow: "visible" }}
+          viewBox="0 0 100 100"
+          aria-hidden="true"
+        >
+          <circle cx="50" cy="50" r="48" fill="none" stroke="#0E233C" strokeWidth="1" opacity="0.95" />
+          <circle cx="50" cy="50" r="43.6" fill="none" stroke="#0E233C" strokeWidth="0.5" opacity="0.6" />
+        </svg>
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            paddingBottom: ".05em",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/ramillete-mono-navy.png" alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "baseline",
+              lineHeight: 1,
+              marginTop: ".01em",
+              fontFamily: "var(--font-jost, 'Jost', sans-serif)",
+            }}
+          >
+            <span style={{ fontWeight: 500, fontSize: ".115em", color: "#0E233C" }}>BROT</span>
+            <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Kicker */}
+      <p className="brot-hero-kicker" style={{ marginTop: "48px" }}>
+        Micropanadería de masa madre
+      </p>
+
+      {/* Título */}
+      <h1
+        className="brot-hero-h1"
+        style={{
+          fontFamily: serif,
+          fontWeight: 800,
+          fontSize: "clamp(40px, 7.5vw, 60px)",
+          lineHeight: 1.08,
+          letterSpacing: "-.015em",
+          color: "#0E233C",
+          margin: "26px 0 0",
+          maxWidth: "13ch",
+          textWrap: "balance" as React.CSSProperties["textWrap"],
+        }}
+      >
+        Pan de fermentación natural,{" "}
+        <em style={{ fontStyle: "normal", color: "#C8851A" }}>como debe ser.</em>
+      </h1>
+
+      {/* CTA */}
+      <button
+        onClick={onReservar}
+        className="brot-hero-cta inline-flex items-center gap-[11px] font-bold border-none cursor-pointer"
+        style={{
+          marginTop: "44px",
+          fontSize: "16px",
+          letterSpacing: ".01em",
+          color: "#0E233C",
+          background: "#C8851A",
+          padding: "18px 30px",
+          borderRadius: "12px",
+          boxShadow: "0 16px 34px -14px rgba(200,133,26,.7)",
+          transition: ctaTransition,
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.transform = "translateY(-2px)";
+          e.currentTarget.style.background = "#E0A33A";
+          e.currentTarget.style.boxShadow = "0 20px 40px -14px rgba(200,133,26,.85)";
+          const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
+          if (arrow) arrow.style.transform = "translateX(4px)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.transform = "";
+          e.currentTarget.style.background = "#C8851A";
+          e.currentTarget.style.boxShadow = "0 16px 34px -14px rgba(200,133,26,.7)";
+          const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
+          if (arrow) arrow.style.transform = "";
+        }}
+        onMouseDown={(e) => { e.currentTarget.style.transform = "translateY(-2px) scale(.97)"; }}
+        onMouseUp={(e) => { e.currentTarget.style.transform = "translateY(-2px)"; }}
+        onTouchStart={(e) => { e.currentTarget.style.transform = "scale(.97)"; }}
+        onTouchEnd={(e) => { e.currentTarget.style.transform = ""; }}
+      >
+        Reservá tu BROT{" "}
+        <span className="arrow" style={{ fontSize: "17px", display: "inline-block", transition: "transform .2s cubic-bezier(.2,.7,.3,1)" }}>{"→"}</span>
+      </button>
+    </section>
+  );
+}

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import BrotWordmark from "@/components/BrotWordmark";
+
 interface HomeHeroProps {
   onReservar: () => void;
 }
@@ -61,32 +63,7 @@ export default function HomeHero({ onReservar }: HomeHeroProps) {
           <circle cx="50" cy="50" r="48" fill="none" stroke="#0E233C" strokeWidth="1" opacity="0.95" />
           <circle cx="50" cy="50" r="43.6" fill="none" stroke="#0E233C" strokeWidth="0.5" opacity="0.6" />
         </svg>
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            paddingBottom: ".05em",
-          }}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/ramillete-mono-navy.png" alt="" style={{ height: ".56em", width: "auto", display: "block" }} />
-          <div
-            style={{
-              display: "inline-flex",
-              alignItems: "baseline",
-              lineHeight: 1,
-              marginTop: ".01em",
-              fontFamily: "var(--font-jost, 'Jost', sans-serif)",
-            }}
-          >
-            <span style={{ fontWeight: 500, fontSize: ".115em", color: "#0E233C" }}>BROT</span>
-            <span style={{ fontWeight: 700, fontSize: ".115em", letterSpacing: "-.2em", marginLeft: ".18em", color: "#C8851A" }}>74</span>
-          </div>
-        </div>
+        <BrotWordmark variant="navy" />
       </div>
 
       {/* Kicker */}


### PR DESCRIPTION
## Qué hace
Extrae el hero y el footer del home (`app/page.tsx`) a sus propios componentes (`components/home/HomeHero.tsx`, `components/home/HomeFooter.tsx`), sin cambio visual ni funcional. Es el primer paso de la épica [BRT-129](https://brot74.atlassian.net/browse/BRT-129) — home nuevo estilo nórdico en secciones.

Prepara el terreno para agregar entre hero y footer las secciones de las siguientes stories: historia/filosofía (BRT-131), ingredientes (BRT-132), showcase de productos (BRT-133), cómo funciona el pedido (BRT-134) y la reubicación del CTA de pedidos (BRT-135).

## Por qué
El home actual mezcla el hero, la lógica de routing (slots/menú/checkout) y el footer en un único archivo de 650+ líneas. Antes de sumar 4-5 secciones nuevas conviene separar el hero/footer en componentes propios para que el archivo principal quede como un simple stack de secciones.

## Cómo se probó
- `npm run test:e2e` — pasa el smoke test existente (`e2e/home.spec.ts`: heading + botón "Reservá tu BROT" visibles).
- `npx tsc --noEmit` limpio.
- `npm run lint` sin errores nuevos (los 28 warnings preexistentes no cambian).
- Comparación visual en preview local: pixel-idéntico al home anterior, y el flujo de click en "Reservá tu BROT" → vista de slots sigue funcionando.

Jira: [BRT-130](https://brot74.atlassian.net/browse/BRT-130)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-129]: https://brot74.atlassian.net/browse/BRT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-130]: https://brot74.atlassian.net/browse/BRT-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed home-page hero section featuring the BROT 74 branding, headline, decorative styling, and reservation call-to-action.
  * Added a centered footer with “Powered by” text and a linked Luontek logo.
  * The reservation button now directs visitors to the available slots step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->