### PR TITLE
feat(BRT-131): sección Historia / Filosofía del home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import OrderModal from "@/components/OrderModal";
 import CartBar from "@/components/CartBar";
 import DateSelector from "@/components/DateSelector";
 import HomeHero from "@/components/home/HomeHero";
+import HomeStory from "@/components/home/HomeStory";
 import HomeFooter from "@/components/home/HomeFooter";
 
 interface Slot {
@@ -466,13 +467,13 @@ function HomeContent() {
   }
 
   /* ─── HOME VIEW ──────────────────────────────────────────── */
-  // BRT-130: stack de secciones apilables. Hoy solo Hero + Footer (visual
-  // idéntico al home anterior); las secciones de BRT-131 a BRT-135
-  // (historia, ingredientes, showcase, cómo funciona, pedidos) se agregan
+  // BRT-130: stack de secciones apilables. Las secciones de BRT-132 a
+  // BRT-135 (ingredientes, showcase, cómo funciona, pedidos) se agregan
   // acá en el medio, cada una como su propio componente en components/home/.
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
       <HomeHero onReservar={() => router.push(buildFlowUrl({ step: "slots" }))} />
+      <HomeStory />
       <HomeFooter />
     </div>
   );

--- a/components/home/HomeStory.tsx
+++ b/components/home/HomeStory.tsx
@@ -1,0 +1,36 @@
+// BRT-131: segunda sección del home — historia/filosofía de la marca.
+// Bloque de solo texto, sin fotos (BROT74 es una nano panadería sin local
+// a la calle: no hay fotos de local que mostrar acá). Estilo editorial
+// tipo "Om" de tobrod.dk — kicker + tres párrafos cortos, sin cards ni
+// sombras, mucho aire vertical.
+//
+// Copy borrador (ver comentario en BRT-131 con el mismo texto) — cambiable
+// libremente, no hay detalles factuales reales todavía (cuándo arrancó,
+// quién hornea).
+export default function HomeStory() {
+  return (
+    <section className="bg-navy px-6 py-24 md:py-32">
+      <div className="max-w-[600px] mx-auto text-center">
+        <p className="brot-hero-kicker">Sobre BROT 74</p>
+
+        <div className="mt-10 space-y-6 text-[17px] md:text-[18px] leading-[1.75] text-cream/85">
+          <p>
+            BROT 74 nació en una cocina de casa, no en un local. Horneamos en
+            tandas chicas, con el ritmo que pide la masa madre: no se apura,
+            no se automatiza.
+          </p>
+          <p>
+            Cada pan pasa por una fermentación larga y natural — la misma
+            técnica de siempre, sin atajos. Elegimos calidad sobre volumen:
+            preferimos hornear poco y bien, a mucho y parejo.
+          </p>
+          <p>
+            No tenemos local a la calle. Tenemos un horno, un puñado de
+            fechas por semana, y ganas de que cada pedido llegue como si
+            fuera el único.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Qué hace
Agrega la segunda sección del home nuevo (después del hero, antes del footer): un bloque de solo texto con la historia/filosofía de BROT74 — `components/home/HomeStory.tsx`. Parte de la épica [BRT-129](https://brot74.atlassian.net/browse/BRT-129), depende de [BRT-130](https://brot74.atlassian.net/browse/BRT-130) (ya mergeado).

## Diseño
Fondo navy, kicker ámbar ("Sobre BROT 74", reutiliza `.brot-hero-kicker`), tres párrafos cortos en crema al 85% de opacidad — sin cards, sin sombras, mucho aire vertical. Mismos tokens de color/tipografía que el hero.

## Copy
Borrador, mismo texto que dejé como comentario en [BRT-131](https://brot74.atlassian.net/browse/BRT-131). Los detalles factuales (cuándo arrancó, quién hornea) son placeholder de tono — el dueño los va a ajustar.

## Cómo se probó
- `npm run test:e2e` — smoke test existente sigue pasando.
- `npx tsc --noEmit` y `npm run lint` limpios.
- Verificación de estilos vía computed style en preview local (fondo navy `rgb(14,35,60)`, kicker ámbar `rgb(200,133,26)`, texto cream/85 `oklab(... / 0.85)`).

Jira: [BRT-131](https://brot74.atlassian.net/browse/BRT-131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-129]: https://brot74.atlassian.net/browse/BRT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-130]: https://brot74.atlassian.net/browse/BRT-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-131]: https://brot74.atlassian.net/browse/BRT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-131]: https://brot74.atlassian.net/browse/BRT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ