### PR TITLE
feat(BRT-131, BRT-132): rediseñar Historia + sección Ingredientes del home

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -36,6 +36,24 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* ── Reveal: fade + translateY al entrar en viewport (components/Reveal.tsx) ── */
+.brot-reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.brot-reveal.in {
+  opacity: 1;
+  transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .brot-reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
 /* ── Badge pulsante "Pedidos abiertos" ── */
 @keyframes brot-pulse {
   0%, 100% { box-shadow: 0 0 0 0 #16C65A, 0 0 7px 1px #16C65A; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import CartBar from "@/components/CartBar";
 import DateSelector from "@/components/DateSelector";
 import HomeHero from "@/components/home/HomeHero";
 import HomeStory from "@/components/home/HomeStory";
+import HomeIngredients from "@/components/home/HomeIngredients";
 import HomeFooter from "@/components/home/HomeFooter";
 
 interface Slot {
@@ -467,13 +468,14 @@ function HomeContent() {
   }
 
   /* ─── HOME VIEW ──────────────────────────────────────────── */
-  // BRT-130: stack de secciones apilables. Las secciones de BRT-132 a
-  // BRT-135 (ingredientes, showcase, cómo funciona, pedidos) se agregan
-  // acá en el medio, cada una como su propio componente en components/home/.
+  // BRT-130: stack de secciones apilables. Las secciones de BRT-133 a
+  // BRT-135 (showcase, cómo funciona, pedidos) se agregan acá en el
+  // medio, cada una como su propio componente en components/home/.
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
       <HomeHero onReservar={() => router.push(buildFlowUrl({ step: "slots" }))} />
       <HomeStory />
+      <HomeIngredients />
       <HomeFooter />
     </div>
   );

--- a/components/GrainOverlay.tsx
+++ b/components/GrainOverlay.tsx
@@ -1,0 +1,25 @@
+interface GrainOverlayProps {
+  /** cream: sección clara (hero) — grano oscurece con multiply. navy: sección oscura — grano aclara con overlay. */
+  variant?: "cream" | "navy";
+}
+
+// Extraído del hero (BRT-90 / BRT-130) para reusar en las secciones navy
+// nuevas (BRT-131, BRT-132) sin duplicar el mismo SVG de ruido inline en
+// cada archivo. Puramente CSS/SVG, no suma ningún asset.
+export default function GrainOverlay({ variant = "cream" }: GrainOverlayProps) {
+  const isNavy = variant === "navy";
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        backgroundImage:
+          "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+        opacity: isNavy ? 0.05 : 0.035,
+        mixBlendMode: isNavy ? "overlay" : "multiply",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/components/Reveal.tsx
+++ b/components/Reveal.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface RevealProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+// Fade + translateY al entrar en viewport, vía IntersectionObserver.
+// Mismo patrón que ya usa app/como-se-hizo/page.tsx (su propio .reveal
+// scoped a esa página) — acá como componente reusable para las secciones
+// nuevas del home (BRT-131, BRT-132...). Respeta prefers-reduced-motion.
+export default function Reveal({ children, className }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  // Lazy initializer (no un efecto) para que el caso reduced-motion no
+  // dispare un setState síncrono dentro de un effect.
+  const [visible, setVisible] = useState(
+    () => typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+
+  useEffect(() => {
+    if (visible) return; // ya resuelto por el estado inicial (reduced motion)
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.15 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [visible]);
+
+  return (
+    <div ref={ref} className={`brot-reveal${visible ? " in" : ""}${className ? ` ${className}` : ""}`}>
+      {children}
+    </div>
+  );
+}

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import BrotWordmark from "@/components/BrotWordmark";
+import GrainOverlay from "@/components/GrainOverlay";
 
 interface HomeHeroProps {
   onReservar: () => void;
@@ -28,20 +29,8 @@ export default function HomeHero({ onReservar }: HomeHeroProps) {
       }}
     >
       {/* Grano sutil — le da algo de textura "hecho a mano" al fondo
-         crema, que si no queda un poco plano/corporativo. Puramente
-         CSS (SVG inline), no suma ningún asset nuevo. */}
-      <div
-        aria-hidden="true"
-        style={{
-          position: "absolute",
-          inset: 0,
-          backgroundImage:
-            "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
-          opacity: 0.035,
-          mixBlendMode: "multiply",
-          pointerEvents: "none",
-        }}
-      />
+         crema, que si no queda un poco plano/corporativo. */}
+      <GrainOverlay variant="cream" />
 
       {/* Sello — v30: ramillete navy sobre crema (antes crema sobre navy) */}
       <div

--- a/components/home/HomeIngredients.tsx
+++ b/components/home/HomeIngredients.tsx
@@ -1,35 +1,63 @@
+import GrainOverlay from "@/components/GrainOverlay";
+import Reveal from "@/components/Reveal";
+
+const NOT_INCLUDED = ["Sin levadura comercial", "Sin mejoradores", "Sin conservantes"];
+
 // BRT-132: tercera sección del home — ingredientes/materia prima.
-// Mismo tratamiento tipográfico y de paleta que HomeStory (BRT-131,
-// consistencia pedida por el criterio de aceptación): fondo navy, kicker
-// ámbar, cuerpo en crema. Un hairline arriba (mismo patrón que el borde
-// de HomeFooter) marca el corte entre ambas secciones de texto para que
-// no se lean como un solo bloque continuo.
+// v2 (feedback: la v1 centrada se veía casi idéntica a Historia). Mismo
+// layout editorial asimétrico (rail + columna de contenido) que
+// HomeStory para dar continuidad, pero con su propia variación: acá la
+// pull quote es corta ("Harina, agua, sal y masa madre. Nada más.") y se
+// suma una fila de tags con lo que el pan NO lleva, en vez de un tercer
+// párrafo — así las dos secciones de texto no se leen como un espejo
+// una de la otra.
 //
 // Copy anclado en datos reales del catálogo (prisma/seed.ts): todos los
 // productos comparten harina + agua + sal + masa madre, sin aditivos —
 // ver también el comentario dejado en BRT-132.
 export default function HomeIngredients() {
   return (
-    <section className="bg-navy border-t border-cream/10 px-6 py-24 md:py-32">
-      <div className="max-w-[600px] mx-auto text-center">
-        <p className="brot-hero-kicker">Ingredientes</p>
-
-        <div className="mt-10 space-y-6 text-[17px] md:text-[18px] leading-[1.75] text-cream/85">
-          <p>
-            Todos nuestros panes se hacen con lo mismo de siempre: harina,
-            agua, sal y masa madre propia. Nada de levadura comercial, nada
-            de mejoradores, nada de conservantes.
-          </p>
-          <p>
-            La fermentación larga hace el trabajo que otros le piden a los
-            aditivos: más sabor, mejor digestión, una corteza que realmente
-            cruje.
-          </p>
-          <p>
-            Elegimos harinas simples y trazables. Si un ingrediente no lo
-            reconocerías en tu propia cocina, no entra en el pan.
-          </p>
+    <section className="relative bg-navy border-t border-cream/10 overflow-hidden">
+      <GrainOverlay variant="navy" />
+      <div className="relative max-w-[1080px] mx-auto px-6 md:px-10 py-24 md:py-36 grid md:grid-cols-[180px_1fr] gap-8 md:gap-16">
+        {/* Rail: índice + eyebrow */}
+        <div className="flex items-center gap-4 md:flex-col md:items-start md:gap-5">
+          <span className="font-mono text-amber text-[13px] tracking-[.08em]">02 — 06</span>
+          <span className="text-cream/50 text-[11px] font-semibold uppercase tracking-[.24em]">
+            Ingredientes
+          </span>
         </div>
+
+        {/* Contenido */}
+        <Reveal>
+          <p className="text-cream text-[28px] md:text-[38px] font-bold leading-[1.2] tracking-[-.01em] max-w-[16ch] text-balance">
+            Harina, agua, sal y{" "}
+            <span className="text-amber">masa madre. Nada más.</span>
+          </p>
+
+          <div className="mt-8 space-y-5 text-[16px] md:text-[17px] leading-[1.75] text-cream/60 max-w-[54ch]">
+            <p>
+              La fermentación larga hace el trabajo que otros le piden a los
+              aditivos: más sabor, mejor digestión, una corteza que
+              realmente cruje.
+            </p>
+            <p>
+              Elegimos harinas simples y trazables. Si un ingrediente no lo
+              reconocerías en tu propia cocina, no entra en el pan.
+            </p>
+          </div>
+
+          <ul className="mt-8 flex flex-wrap gap-3">
+            {NOT_INCLUDED.map((item) => (
+              <li
+                key={item}
+                className="border border-cream/20 text-cream/70 text-[11px] font-semibold uppercase tracking-[.08em] rounded-full px-4 py-2"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </Reveal>
       </div>
     </section>
   );

--- a/components/home/HomeIngredients.tsx
+++ b/components/home/HomeIngredients.tsx
@@ -1,0 +1,36 @@
+// BRT-132: tercera sección del home — ingredientes/materia prima.
+// Mismo tratamiento tipográfico y de paleta que HomeStory (BRT-131,
+// consistencia pedida por el criterio de aceptación): fondo navy, kicker
+// ámbar, cuerpo en crema. Un hairline arriba (mismo patrón que el borde
+// de HomeFooter) marca el corte entre ambas secciones de texto para que
+// no se lean como un solo bloque continuo.
+//
+// Copy anclado en datos reales del catálogo (prisma/seed.ts): todos los
+// productos comparten harina + agua + sal + masa madre, sin aditivos —
+// ver también el comentario dejado en BRT-132.
+export default function HomeIngredients() {
+  return (
+    <section className="bg-navy border-t border-cream/10 px-6 py-24 md:py-32">
+      <div className="max-w-[600px] mx-auto text-center">
+        <p className="brot-hero-kicker">Ingredientes</p>
+
+        <div className="mt-10 space-y-6 text-[17px] md:text-[18px] leading-[1.75] text-cream/85">
+          <p>
+            Todos nuestros panes se hacen con lo mismo de siempre: harina,
+            agua, sal y masa madre propia. Nada de levadura comercial, nada
+            de mejoradores, nada de conservantes.
+          </p>
+          <p>
+            La fermentación larga hace el trabajo que otros le piden a los
+            aditivos: más sabor, mejor digestión, una corteza que realmente
+            cruje.
+          </p>
+          <p>
+            Elegimos harinas simples y trazables. Si un ingrediente no lo
+            reconocerías en tu propia cocina, no entra en el pan.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/home/HomeStory.tsx
+++ b/components/home/HomeStory.tsx
@@ -1,35 +1,52 @@
+import GrainOverlay from "@/components/GrainOverlay";
+import Reveal from "@/components/Reveal";
+
 // BRT-131: segunda sección del home — historia/filosofía de la marca.
-// Bloque de solo texto, sin fotos (BROT74 es una nano panadería sin local
-// a la calle: no hay fotos de local que mostrar acá). Estilo editorial
-// tipo "Om" de tobrod.dk — kicker + tres párrafos cortos, sin cards ni
-// sombras, mucho aire vertical.
+// v2 (feedback: la v1 centrada se veía "ultra básica" al lado de
+// Ingredientes, casi idéntica). Ahora es un layout editorial asimétrico
+// — rail izquierdo con índice + eyebrow, columna derecha con una frase
+// de apertura grande ("pull quote") y el cuerpo más chico y atenuado —
+// en vez de kicker + párrafos centrados. Sin fotos (BROT74 es una nano
+// panadería sin local a la calle).
 //
-// Copy borrador (ver comentario en BRT-131 con el mismo texto) — cambiable
-// libremente, no hay detalles factuales reales todavía (cuándo arrancó,
-// quién hornea).
+// Copy borrador (ver comentario en BRT-131) — cambiable libremente, no
+// hay detalles factuales reales todavía (cuándo arrancó, quién hornea).
 export default function HomeStory() {
   return (
-    <section className="bg-navy px-6 py-24 md:py-32">
-      <div className="max-w-[600px] mx-auto text-center">
-        <p className="brot-hero-kicker">Sobre BROT 74</p>
-
-        <div className="mt-10 space-y-6 text-[17px] md:text-[18px] leading-[1.75] text-cream/85">
-          <p>
-            BROT 74 nació en una cocina de casa, no en un local. Horneamos en
-            tandas chicas, con el ritmo que pide la masa madre: no se apura,
-            no se automatiza.
-          </p>
-          <p>
-            Cada pan pasa por una fermentación larga y natural — la misma
-            técnica de siempre, sin atajos. Elegimos calidad sobre volumen:
-            preferimos hornear poco y bien, a mucho y parejo.
-          </p>
-          <p>
-            No tenemos local a la calle. Tenemos un horno, un puñado de
-            fechas por semana, y ganas de que cada pedido llegue como si
-            fuera el único.
-          </p>
+    <section className="relative bg-navy overflow-hidden">
+      <GrainOverlay variant="navy" />
+      <div className="relative max-w-[1080px] mx-auto px-6 md:px-10 py-24 md:py-36 grid md:grid-cols-[180px_1fr] gap-8 md:gap-16">
+        {/* Rail: índice + eyebrow */}
+        <div className="flex items-center gap-4 md:flex-col md:items-start md:gap-5">
+          <span className="font-mono text-amber text-[13px] tracking-[.08em]">01 — 06</span>
+          <span className="text-cream/50 text-[11px] font-semibold uppercase tracking-[.24em]">
+            Sobre BROT 74
+          </span>
         </div>
+
+        {/* Contenido */}
+        <Reveal>
+          <p className="text-cream text-[28px] md:text-[38px] font-bold leading-[1.2] tracking-[-.01em] max-w-[16ch] text-balance">
+            Nació en una cocina de casa,{" "}
+            <span className="text-amber">no en un local.</span>
+          </p>
+
+          <div className="mt-8 space-y-5 text-[16px] md:text-[17px] leading-[1.75] text-cream/60 max-w-[54ch]">
+            <p>
+              Horneamos en tandas chicas, con el ritmo que pide la masa
+              madre: no se apura, no se automatiza.
+            </p>
+            <p>
+              Cada pan pasa por una fermentación larga y natural — la misma
+              técnica de siempre, sin atajos. Preferimos hornear poco y
+              bien, a mucho y parejo.
+            </p>
+            <p>
+              Tenemos un horno, un puñado de fechas por semana, y ganas de
+              que cada pedido llegue como si fuera el único.
+            </p>
+          </div>
+        </Reveal>
       </div>
     </section>
   );


### PR DESCRIPTION
## Qué hace
1. **BRT-132**: agrega la sección Ingredientes/Materia prima (`components/home/HomeIngredients.tsx`), entre Historia y el footer.
2. **Rediseño en vivo de ambas** (feedback del dueño del proyecto: la v1 centrada se veía "ultra básica" y las dos secciones eran casi indistinguibles): layout editorial asimétrico — rail con índice ("01 — 06" / "02 — 06") + eyebrow a la izquierda, pull-quote grande + cuerpo atenuado a la derecha. Ingredientes suma una fila de tags ("Sin levadura comercial", "Sin mejoradores", "Sin conservantes") para diferenciarse de Historia en vez de ser un espejo.

Parte de la épica [BRT-129](https://brot74.atlassian.net/browse/BRT-129).

## Nuevo
- `components/GrainOverlay.tsx` — extrae la textura de ruido del hero (variant cream/navy), reusada ahora en 3 lugares en vez de duplicar el SVG inline.
- `components/Reveal.tsx` — fade + translateY al entrar en viewport (IntersectionObserver, respeta `prefers-reduced-motion`), mismo patrón que ya usaba `como-se-hizo/page.tsx` pero como componente reusable.

## Copy
Historia: borrador de tono (comentario en BRT-131). Ingredientes: anclado en datos reales del catálogo (`prisma/seed.ts`).

## Cómo se probó
- `npm run test:e2e` y `npx tsc --noEmit` / `npm run lint` limpios.
- Verificación por computed style en preview local: fondo navy, grid asimétrico `180px + resto` en desktop (1280px), apilado en mobile (375px), transición del Reveal confirmada manualmente (`opacity` 0→1 al togglear la clase `.in`).

Jira: [BRT-132](https://brot74.atlassian.net/browse/BRT-132), [BRT-131](https://brot74.atlassian.net/browse/BRT-131) (revisión post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-129]: https://brot74.atlassian.net/browse/BRT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-132]: https://brot74.atlassian.net/browse/BRT-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ