### PR TITLE
feat(BRT-133): sección Showcase de productos del home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import DateSelector from "@/components/DateSelector";
 import HomeHero from "@/components/home/HomeHero";
 import HomeStory from "@/components/home/HomeStory";
 import HomeIngredients from "@/components/home/HomeIngredients";
+import HomeShowcase from "@/components/home/HomeShowcase";
 import HomeFooter from "@/components/home/HomeFooter";
 
 interface Slot {
@@ -468,14 +469,15 @@ function HomeContent() {
   }
 
   /* ─── HOME VIEW ──────────────────────────────────────────── */
-  // BRT-130: stack de secciones apilables. Las secciones de BRT-133 a
-  // BRT-135 (showcase, cómo funciona, pedidos) se agregan acá en el
-  // medio, cada una como su propio componente en components/home/.
+  // BRT-130: stack de secciones apilables. Las secciones de BRT-134 y
+  // BRT-135 (cómo funciona, pedidos) se agregan acá en el medio, cada
+  // una como su propio componente en components/home/.
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
       <HomeHero onReservar={() => router.push(buildFlowUrl({ step: "slots" }))} />
       <HomeStory />
       <HomeIngredients />
+      <HomeShowcase />
       <HomeFooter />
     </div>
   );

--- a/components/home/HomeShowcase.tsx
+++ b/components/home/HomeShowcase.tsx
@@ -30,7 +30,10 @@ export default function HomeShowcase() {
 
   useEffect(() => {
     fetch("/api/products")
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`GET /api/products -> ${r.status}`);
+        return r.json();
+      })
       .then((data: ShowcaseProduct[]) => {
         setProducts(data.filter((p) => p.imageUrl).slice(0, 3));
       })

--- a/components/home/HomeShowcase.tsx
+++ b/components/home/HomeShowcase.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Reveal from "@/components/Reveal";
+
+interface ShowcaseProduct {
+  id: number;
+  name: string;
+  weight: string;
+  imageUrl: string;
+  focalX: number;
+  focalY: number;
+  imageScale: number;
+}
+
+// BRT-133: cuarta sección del home — showcase de productos. Acá es donde
+// de verdad se aplica la referencia de tobrod.dk (fotografía de producto
+// a pantalla casi completa, sin cards/sombras) — las secciones de texto
+// anteriores (Historia, Ingredientes) tomaron otro camino editorial, pero
+// esta es fotografía pura. Fondo crema (vs. el navy de las dos
+// anteriores) para que la foto respire y para variar el ritmo del scroll.
+//
+// Trae los productos reales vía GET /api/products (sin slotId — listado
+// público sin stock, mismo endpoint que ya existe) en vez de hardcodear
+// rutas de imagen: así siempre muestra lo que hay activo en catálogo,
+// también en producción. Si la carga falla o no hay productos con foto,
+// la sección no se renderiza (nada roto, simplemente no aparece).
+export default function HomeShowcase() {
+  const [products, setProducts] = useState<ShowcaseProduct[] | null>(null);
+
+  useEffect(() => {
+    fetch("/api/products")
+      .then((r) => r.json())
+      .then((data: ShowcaseProduct[]) => {
+        setProducts(data.filter((p) => p.imageUrl).slice(0, 3));
+      })
+      .catch(() => setProducts([]));
+  }, []);
+
+  if (!products || products.length === 0) return null;
+
+  return (
+    <section className="bg-cream">
+      <div className="text-center pt-20 md:pt-28">
+        <p className="brot-hero-kicker">Nuestro pan</p>
+      </div>
+
+      <Reveal className="mt-10 md:mt-14">
+        <div className="flex flex-col md:flex-row">
+          {products.map((p) => (
+            <div
+              key={p.id}
+              className="relative w-full md:flex-1 aspect-[4/5] md:aspect-auto md:h-[78vh] overflow-hidden"
+            >
+              <div
+                className="absolute inset-0 bg-cover"
+                style={{
+                  backgroundImage: `url(${p.imageUrl})`,
+                  backgroundPosition: `${p.focalX}% ${p.focalY}%`,
+                  transform: `scale(${p.imageScale})`,
+                  transformOrigin: `${p.focalX}% ${p.focalY}%`,
+                }}
+              />
+              <div
+                className="absolute inset-x-0 bottom-0 h-1/2 pointer-events-none"
+                style={{ background: "linear-gradient(to top, rgba(14,35,60,.55), rgba(14,35,60,0))" }}
+              />
+              <div className="absolute bottom-0 left-0 p-6 md:p-8">
+                <div className="text-cream font-bold text-[22px] md:text-[24px] leading-tight">
+                  {p.name}
+                </div>
+                {p.weight && (
+                  <div className="text-cream/75 text-[13px] font-medium mt-1">{p.weight}</div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Reveal>
+    </section>
+  );
+}


### PR DESCRIPTION
## Qué hace
Agrega la sección Showcase de productos (`components/home/HomeShowcase.tsx`), entre Ingredientes y el footer. Parte de la épica [BRT-129](https://brot74.atlassian.net/browse/BRT-129).

Es la sección donde de verdad se aplica la referencia visual de tobrod.dk (fotografía a pantalla casi completa, sin cards/sombras) — las dos secciones de texto anteriores (Historia, Ingredientes) terminaron yendo por un camino editorial distinto, pero acá es foto pura.

## Diseño
2-3 fotos de producto en triptych (desktop) / apiladas (mobile), fondo crema para variar el ritmo frente al navy de las secciones anteriores, gradiente sutil + nombre/peso superpuesto abajo de cada foto.

## Datos
Trae los productos reales vía `GET /api/products` (endpoint público ya existente, sin `slotId`) en vez de hardcodear rutas de imagen locales — muestra siempre el catálogo activo real. Si falla la carga o no hay productos con foto, la sección no se renderiza (sin romper el resto del home). Reusa el mismo criterio de recorte (`focalX`/`focalY`/`imageScale`) que `ProductCard`.

## Cómo se probó
- `npm run test:e2e` y `npx tsc --noEmit` / `npm run lint` limpios.
- Seedeada la base local con 3 productos de prueba con foto real (`prisma/seed.ts` + imágenes ya existentes en `public/products/`) para verificar el render.
- Layout confirmado por computed style: fila (triptych) a 1280px, columna a mobile.

Jira: [BRT-133](https://brot74.atlassian.net/browse/BRT-133)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-129]: https://brot74.atlassian.net/browse/BRT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-133]: https://brot74.atlassian.net/browse/BRT-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a product showcase section to the home page.
  - Displays up to three products with available images in full-bleed visual cards.
  - Includes product names, weights, image focal-point positioning, and gradient overlays.
  - The section remains hidden when product imagery is unavailable or cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->