### PR TITLE
feat(BRT-134): sección Cómo funciona el pedido del home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import HomeHero from "@/components/home/HomeHero";
 import HomeStory from "@/components/home/HomeStory";
 import HomeIngredients from "@/components/home/HomeIngredients";
 import HomeShowcase from "@/components/home/HomeShowcase";
+import HomeHowItWorks from "@/components/home/HomeHowItWorks";
 import HomeFooter from "@/components/home/HomeFooter";
 
 interface Slot {
@@ -469,15 +470,16 @@ function HomeContent() {
   }
 
   /* ─── HOME VIEW ──────────────────────────────────────────── */
-  // BRT-130: stack de secciones apilables. Las secciones de BRT-134 y
-  // BRT-135 (cómo funciona, pedidos) se agregan acá en el medio, cada
-  // una como su propio componente en components/home/.
+  // BRT-130: stack de secciones apilables. La sección de BRT-135
+  // (pedidos) se agrega acá antes del footer, como su propio componente
+  // en components/home/.
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
       <HomeHero onReservar={() => router.push(buildFlowUrl({ step: "slots" }))} />
       <HomeStory />
       <HomeIngredients />
       <HomeShowcase />
+      <HomeHowItWorks />
       <HomeFooter />
     </div>
   );

--- a/components/home/HomeHowItWorks.tsx
+++ b/components/home/HomeHowItWorks.tsx
@@ -1,0 +1,71 @@
+import GrainOverlay from "@/components/GrainOverlay";
+import Reveal from "@/components/Reveal";
+
+const STEPS = [
+  {
+    title: "Elegí tu pan",
+    desc: "Elegís la fecha y armás tu pedido online, según lo que haya disponible para esa tanda.",
+  },
+  {
+    title: "Pagá por transferencia",
+    desc: "Confirmás con una transferencia. Sin filas, sin efectivo, a tu ritmo.",
+  },
+  {
+    title: "Retirá en tu horario",
+    desc: "Pasás a buscarlo en el lugar y la franja horaria de tu fecha — horneamos por tandas, no hay local abierto todo el día.",
+  },
+];
+
+// BRT-134: quinta sección del home — cómo funciona el pedido. Pasos
+// numerados tipo "Dagens gang" de tobrod.dk, adaptados a que BROT74 no
+// tiene local físico al que ir en cualquier momento (paso 3 lo aclara
+// explícitamente). Mismo tratamiento navy/rail/pull-quote que Historia
+// e Ingredientes, pero el cuerpo es una lista con línea conectora en vez
+// de párrafos — mismo patrón visual que ya usa el pipeline de
+// app/como-se-hizo/page.tsx, adaptado a la paleta cream/amber sobre navy.
+export default function HomeHowItWorks() {
+  return (
+    <section className="relative bg-navy border-t border-cream/10 overflow-hidden">
+      <GrainOverlay variant="navy" />
+      <div className="relative max-w-[1080px] mx-auto px-6 md:px-10 py-24 md:py-36 grid md:grid-cols-[180px_1fr] gap-8 md:gap-16">
+        {/* Rail: índice + eyebrow */}
+        <div className="flex items-center gap-4 md:flex-col md:items-start md:gap-5">
+          <span className="font-mono text-amber text-[13px] tracking-[.08em]">03 — 03</span>
+          <span className="text-cream/50 text-[11px] font-semibold uppercase tracking-[.24em]">
+            Cómo funciona
+          </span>
+        </div>
+
+        {/* Contenido */}
+        <Reveal>
+          <p className="text-cream text-[28px] md:text-[38px] font-bold leading-[1.2] tracking-[-.01em] max-w-[18ch] text-balance">
+            Pedís hoy,{" "}
+            <span className="text-amber">retirás en tu fecha.</span>
+          </p>
+
+          <div className="relative mt-10 md:mt-12 max-w-[54ch] pl-9">
+            <div
+              aria-hidden="true"
+              className="absolute left-3 top-1 bottom-1 w-px bg-cream/15"
+            />
+            <ol className="space-y-9">
+              {STEPS.map((step, i) => (
+                <li key={step.title} className="relative">
+                  <span className="absolute -left-9 top-0 w-6 h-6 rounded-full bg-navy border-2 border-amber flex items-center justify-center text-amber font-mono text-[11px] leading-none">
+                    {i + 1}
+                  </span>
+                  <div className="text-cream font-semibold text-[17px] mb-1.5">
+                    {step.title}
+                  </div>
+                  <div className="text-cream/60 text-[15px] leading-[1.7]">
+                    {step.desc}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/components/home/HomeIngredients.tsx
+++ b/components/home/HomeIngredients.tsx
@@ -22,7 +22,7 @@ export default function HomeIngredients() {
       <div className="relative max-w-[1080px] mx-auto px-6 md:px-10 py-24 md:py-36 grid md:grid-cols-[180px_1fr] gap-8 md:gap-16">
         {/* Rail: índice + eyebrow */}
         <div className="flex items-center gap-4 md:flex-col md:items-start md:gap-5">
-          <span className="font-mono text-amber text-[13px] tracking-[.08em]">02 — 06</span>
+          <span className="font-mono text-amber text-[13px] tracking-[.08em]">02 — 03</span>
           <span className="text-cream/50 text-[11px] font-semibold uppercase tracking-[.24em]">
             Ingredientes
           </span>

--- a/components/home/HomeStory.tsx
+++ b/components/home/HomeStory.tsx
@@ -18,7 +18,7 @@ export default function HomeStory() {
       <div className="relative max-w-[1080px] mx-auto px-6 md:px-10 py-24 md:py-36 grid md:grid-cols-[180px_1fr] gap-8 md:gap-16">
         {/* Rail: índice + eyebrow */}
         <div className="flex items-center gap-4 md:flex-col md:items-start md:gap-5">
-          <span className="font-mono text-amber text-[13px] tracking-[.08em]">01 — 06</span>
+          <span className="font-mono text-amber text-[13px] tracking-[.08em]">01 — 03</span>
           <span className="text-cream/50 text-[11px] font-semibold uppercase tracking-[.24em]">
             Sobre BROT 74
           </span>


### PR DESCRIPTION
## Qué hace
Agrega la sección "Cómo funciona el pedido" (`components/home/HomeHowItWorks.tsx`), entre Showcase y el footer. Parte de la épica [BRT-129](https://brot74.atlassian.net/browse/BRT-129).

3 pasos numerados (elegí → pagá por transferencia → retirá en tu horario), estilo "Dagens gang" de tobrod.dk pero adaptados a que BROT74 no tiene local físico al que ir en cualquier momento — el paso 3 lo aclara explícitamente (retiro en el slot/horario elegido, no visita libre).

## Diseño
Lista con línea conectora + círculos numerados (mismo patrón visual que ya usa el pipeline de `app/como-se-hizo/page.tsx`, adaptado a cream/ámbar sobre navy). Mismo rail lateral (índice + eyebrow) que Historia/Ingredientes.

## Fix de paso
Historia e Ingredientes mostraban "— 06" en el índice (contando las 6 secciones del home completo), pero ese rail numerado solo lo usan estas 3 secciones de texto — Hero, Showcase y Pedidos tienen tratamientos visuales propios sin rail. Corregido a "— 03" en las tres.

## Cómo se probó
- `npm run test:e2e` y `npx tsc --noEmit` / `npm run lint` limpios.
- Orden de secciones y timeline (3 marcadores numerados + línea conectora) confirmados por computed style en preview local.

Jira: [BRT-134](https://brot74.atlassian.net/browse/BRT-134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-129]: https://brot74.atlassian.net/browse/BRT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-134]: https://brot74.atlassian.net/browse/BRT-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ