### PR TITLE
feat(BRT-135): reubicar CTA de pedidos a sección final "Pedidos" del home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import HomeStory from "@/components/home/HomeStory";
 import HomeIngredients from "@/components/home/HomeIngredients";
 import HomeShowcase from "@/components/home/HomeShowcase";
 import HomeHowItWorks from "@/components/home/HomeHowItWorks";
+import HomePedidos from "@/components/home/HomePedidos";
 import HomeFooter from "@/components/home/HomeFooter";
 
 interface Slot {
@@ -470,16 +471,19 @@ function HomeContent() {
   }
 
   /* ─── HOME VIEW ──────────────────────────────────────────── */
-  // BRT-130: stack de secciones apilables. La sección de BRT-135
-  // (pedidos) se agrega acá antes del footer, como su propio componente
-  // en components/home/.
+  // BRT-130 a BRT-135: stack completo de secciones del home nuevo. El
+  // CTA de pedidos vive ahora en dos lugares (hero + cierre en
+  // HomePedidos) pero dispara la misma navegación — mismo goToSlots,
+  // mismo buildFlowUrl de BRT-95, sin cambios de comportamiento.
+  const goToSlots = () => router.push(buildFlowUrl({ step: "slots" }));
   return (
     <div className="min-h-screen" style={{ background: "#0E233C" }}>
-      <HomeHero onReservar={() => router.push(buildFlowUrl({ step: "slots" }))} />
+      <HomeHero onReservar={goToSlots} />
       <HomeStory />
       <HomeIngredients />
       <HomeShowcase />
       <HomeHowItWorks />
+      <HomePedidos onReservar={goToSlots} />
       <HomeFooter />
     </div>
   );

--- a/components/CtaButton.tsx
+++ b/components/CtaButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+interface CtaButtonProps {
+  onClick: () => void;
+  label: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const ctaTransition = "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s";
+
+// BRT-135: extraído del hero (BRT-90) para reusar en la sección final de
+// Pedidos sin duplicar los handlers de hover/press — mismo botón ámbar,
+// mismo comportamiento, en dos lugares del home. `className` deja que el
+// caller siga enganchando sus propios ajustes responsive (ej. la clase
+// "brot-hero-cta" del hero, con sus overrides de altura comprimida en
+// globals.css) sin que le peguen a otros usos de este botón.
+export default function CtaButton({ onClick, label, className, style }: CtaButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`inline-flex items-center gap-[11px] font-bold border-none cursor-pointer${className ? ` ${className}` : ""}`}
+      style={{
+        fontSize: "16px",
+        letterSpacing: ".01em",
+        color: "#0E233C",
+        background: "#C8851A",
+        padding: "18px 30px",
+        borderRadius: "12px",
+        boxShadow: "0 16px 34px -14px rgba(200,133,26,.7)",
+        transition: ctaTransition,
+        ...style,
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = "translateY(-2px)";
+        e.currentTarget.style.background = "#E0A33A";
+        e.currentTarget.style.boxShadow = "0 20px 40px -14px rgba(200,133,26,.85)";
+        const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
+        if (arrow) arrow.style.transform = "translateX(4px)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "";
+        e.currentTarget.style.background = "#C8851A";
+        e.currentTarget.style.boxShadow = "0 16px 34px -14px rgba(200,133,26,.7)";
+        const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
+        if (arrow) arrow.style.transform = "";
+      }}
+      onMouseDown={(e) => { e.currentTarget.style.transform = "translateY(-2px) scale(.97)"; }}
+      onMouseUp={(e) => { e.currentTarget.style.transform = "translateY(-2px)"; }}
+      onTouchStart={(e) => { e.currentTarget.style.transform = "scale(.97)"; }}
+      onTouchEnd={(e) => { e.currentTarget.style.transform = ""; }}
+    >
+      {label}{" "}
+      <span className="arrow" style={{ fontSize: "17px", display: "inline-block", transition: "transform .2s cubic-bezier(.2,.7,.3,1)" }}>{"→"}</span>
+    </button>
+  );
+}

--- a/components/home/HomeHero.tsx
+++ b/components/home/HomeHero.tsx
@@ -2,14 +2,13 @@
 
 import BrotWordmark from "@/components/BrotWordmark";
 import GrainOverlay from "@/components/GrainOverlay";
+import CtaButton from "@/components/CtaButton";
 
 interface HomeHeroProps {
   onReservar: () => void;
 }
 
 const serif = "var(--font-hanken, 'Hanken Grotesk', system-ui, sans-serif)";
-
-const ctaTransition = "transform .18s cubic-bezier(.2,.7,.3,1), box-shadow .18s";
 
 // BRT-130: primer bloque del home. Extraído tal cual del render de
 // HomeContent (antes era la vista "home" entera) para que el stack de
@@ -80,42 +79,12 @@ export default function HomeHero({ onReservar }: HomeHeroProps) {
       </h1>
 
       {/* CTA */}
-      <button
+      <CtaButton
         onClick={onReservar}
-        className="brot-hero-cta inline-flex items-center gap-[11px] font-bold border-none cursor-pointer"
-        style={{
-          marginTop: "44px",
-          fontSize: "16px",
-          letterSpacing: ".01em",
-          color: "#0E233C",
-          background: "#C8851A",
-          padding: "18px 30px",
-          borderRadius: "12px",
-          boxShadow: "0 16px 34px -14px rgba(200,133,26,.7)",
-          transition: ctaTransition,
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = "translateY(-2px)";
-          e.currentTarget.style.background = "#E0A33A";
-          e.currentTarget.style.boxShadow = "0 20px 40px -14px rgba(200,133,26,.85)";
-          const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
-          if (arrow) arrow.style.transform = "translateX(4px)";
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = "";
-          e.currentTarget.style.background = "#C8851A";
-          e.currentTarget.style.boxShadow = "0 16px 34px -14px rgba(200,133,26,.7)";
-          const arrow = e.currentTarget.querySelector(".arrow") as HTMLElement | null;
-          if (arrow) arrow.style.transform = "";
-        }}
-        onMouseDown={(e) => { e.currentTarget.style.transform = "translateY(-2px) scale(.97)"; }}
-        onMouseUp={(e) => { e.currentTarget.style.transform = "translateY(-2px)"; }}
-        onTouchStart={(e) => { e.currentTarget.style.transform = "scale(.97)"; }}
-        onTouchEnd={(e) => { e.currentTarget.style.transform = ""; }}
-      >
-        Reservá tu BROT{" "}
-        <span className="arrow" style={{ fontSize: "17px", display: "inline-block", transition: "transform .2s cubic-bezier(.2,.7,.3,1)" }}>{"→"}</span>
-      </button>
+        label="Reservá tu BROT"
+        className="brot-hero-cta"
+        style={{ marginTop: "44px" }}
+      />
     </section>
   );
 }

--- a/components/home/HomePedidos.tsx
+++ b/components/home/HomePedidos.tsx
@@ -1,0 +1,58 @@
+import GrainOverlay from "@/components/GrainOverlay";
+import CtaButton from "@/components/CtaButton";
+import Reveal from "@/components/Reveal";
+
+interface HomePedidosProps {
+  onReservar: () => void;
+}
+
+const serif = "var(--font-hanken, 'Hanken Grotesk', system-ui, sans-serif)";
+
+// BRT-135: sexta y última sección del stack — el CTA/flow de pedidos que
+// antes ERA el home entero, reubicado acá como cierre. Mismo
+// `onReservar` (mismo router.push a buildFlowUrl({step:"slots"}), sin
+// cambios de BRT-95) que ya usaba el hero — el flujo de selección de
+// slot → menú → checkout no cambia en nada, solo desde dónde se dispara.
+//
+// Fondo crema + CtaButton compartido (BRT-135) para hacer de bookend
+// visual con el hero: el home abre y cierra en el mismo tono cálido,
+// con las secciones de texto/fotos navy en el medio. El copy del botón
+// es distinto al del hero ("Elegí tu fecha" vs "Reservá tu BROT") para
+// que no se lean como el mismo bloque repetido dos veces.
+export default function HomePedidos({ onReservar }: HomePedidosProps) {
+  return (
+    <section
+      className="relative flex flex-col items-center text-center overflow-hidden"
+      style={{
+        background: "radial-gradient(120% 60% at 50% 30%, rgba(200,133,26,.10), rgba(14,35,60,0) 60%), #F9F5EC",
+        padding: "96px 24px",
+      }}
+    >
+      <GrainOverlay variant="cream" />
+
+      <Reveal className="relative flex flex-col items-center">
+        <p className="brot-hero-kicker">Pedidos</p>
+
+        <h2
+          style={{
+            fontFamily: serif,
+            fontWeight: 800,
+            fontSize: "clamp(28px, 4.5vw, 40px)",
+            lineHeight: 1.15,
+            letterSpacing: "-.01em",
+            color: "#0E233C",
+            margin: "22px 0 0",
+            maxWidth: "16ch",
+            textWrap: "balance" as React.CSSProperties["textWrap"],
+          }}
+        >
+          Tu próximo{" "}
+          <em style={{ fontStyle: "normal", color: "#C8851A" }}>BROT</em>{" "}
+          está a un pedido de distancia.
+        </h2>
+
+        <CtaButton onClick={onReservar} label="Elegí tu fecha" style={{ marginTop: "36px" }} />
+      </Reveal>
+    </section>
+  );
+}


### PR DESCRIPTION
## Qué hace
Última story de la épica [BRT-129](https://brot74.atlassian.net/browse/BRT-129) — home nuevo estilo nórdico completo. Agrega `components/home/HomePedidos.tsx`, el CTA de cierre entre Cómo funciona y el footer.

El CTA/flow de pedidos (selección de slot → menú → checkout) que antes era el home entero ahora también vive en esta sección final, además de en el hero — ambos disparan la misma navegación (`goToSlots` → `buildFlowUrl({step:"slots"})`, sin cambios de BRT-95).

## Diseño
Fondo crema + mismo botón ámbar del hero, para hacer de bookend visual (el home abre y cierra en el mismo tono cálido, con las secciones navy/foto en el medio). Copy del botón distinto al del hero ("Elegí tu fecha" vs "Reservá tu BROT") — variación de copy deliberada, y evita que dos botones con el mismo texto rompan el modo estricto de Playwright en `e2e/home.spec.ts`.

## Refactor
Extraje `components/CtaButton.tsx` desde `HomeHero` para reusar el botón (mismos handlers de hover/press) sin duplicar código — el hero sigue pasando su clase `brot-hero-cta` (overrides de altura comprimida en `globals.css`, específicos del hero a `100svh`) para que Pedidos no herede ese comportamiento.

## Cómo se probó
- `npm run test:e2e` pasa (el hero sigue con su botón propio, sin ambigüedad de texto).
- `npx tsc --noEmit` y `npm run lint` limpios.
- Click manual en el CTA de Pedidos confirmado: navega a `/?step=slots`, igual que el del hero.
- Orden completo de las 6 secciones (Hero → Historia → Ingredientes → Showcase → Cómo funciona → Pedidos → Footer) confirmado en preview local.

Jira: [BRT-135](https://brot74.atlassian.net/browse/BRT-135)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-129]: https://brot74.atlassian.net/browse/BRT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-135]: https://brot74.atlassian.net/browse/BRT-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ