### PR TITLE
fix: reordenar el rail después del hero para que quede debajo en mobile

### DIFF
--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -22,28 +22,6 @@ interface HomeLandingProps {
 export default function HomeLanding({ onReservar }: HomeLandingProps) {
   return (
     <div className="brot-landing">
-      {/* Rail fijo: instagram + CTA — position:fixed en desktop, baja a
-         fila horizontal debajo del hero en ≤820px (ver HomeLanding.css) */}
-      <div className="social">
-        <a
-          href="https://www.instagram.com/brot.74"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Instagram"
-        >
-          <span>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <rect x="3" y="3" width="18" height="18" rx="5"></rect>
-              <circle cx="12" cy="12" r="5"></circle>
-              <circle cx="17.2" cy="6.8" r="1" fill="currentColor" stroke="none"></circle>
-            </svg>
-          </span>
-        </a>
-        <button type="button" className="pill" onClick={onReservar}>
-          Elegí tu BROT
-        </button>
-      </div>
-
       {/* Hero */}
       <header className="hero">
         <div className="hero-bg">
@@ -77,6 +55,34 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
           </div>
         </div>
       </header>
+
+      {/* Rail: position:fixed en desktop (el orden en el DOM no importa,
+         se posiciona por viewport) — en ≤820px pasa a position:static y
+         ahí sí importa el orden: va DESPUÉS del hero en el markup para
+         que cuando deje de ser fijo caiga debajo de la foto, no arriba
+         (fix: en el HTML original del diseño el rail iba antes del
+         header y quedaba arriba de la foto en mobile, al revés de lo
+         que pide el propio ticket — "baja a fila horizontal debajo del
+         hero"). Ver HomeLanding.css. */}
+      <div className="social">
+        <a
+          href="https://www.instagram.com/brot.74"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Instagram"
+        >
+          <span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <rect x="3" y="3" width="18" height="18" rx="5"></rect>
+              <circle cx="12" cy="12" r="5"></circle>
+              <circle cx="17.2" cy="6.8" r="1" fill="currentColor" stroke="none"></circle>
+            </svg>
+          </span>
+        </a>
+        <button type="button" className="pill" onClick={onReservar}>
+          Elegí tu BROT
+        </button>
+      </div>
 
       {/* Idea */}
       <section className="wrap">


### PR DESCRIPTION
## Qué corrige
Bug reportado en producción (Samsung Galaxy S26 Ultra, Chrome y Brave): en mobile el rail (Instagram + "Elegí tu BROT") aparecía **arriba** de la foto del hero en vez de debajo.

## Causa
Heredado del HTML original del diseño (`_design/design_cambios_v31`): `.social` vive antes del `<header class="hero">` en el documento. En desktop no se nota (`position:fixed` no depende del orden en el DOM), pero en ≤820px el rail pasa a `position:static` — ahí sí importa el orden, y terminaba renderizando en su lugar real (antes del hero), al revés de lo que pide el propio ticket [BRT-136](https://brot74.atlassian.net/browse/BRT-136): "el rail deja de ser fijo y baja a una fila horizontal **debajo** del hero".

## Fix
Mover el `<div className="social">` después del `<header className="hero">` en el JSX. Sin cambios de CSS.

## Cómo se probó
- `npm run test:e2e` y `npx tsc --noEmit` / `npm run lint` limpios.
- Mobile (375px): rail arranca exactamente donde termina el hero (`getBoundingClientRect` confirmado).
- Desktop (1300px): sin cambios — `position:fixed`, mismo `top`/`right` que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-136]: https://brot74.atlassian.net/browse/BRT-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ