### PR TITLE
fix: signos de interrogación faltantes en la landing

### DIFF
--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -17,7 +17,8 @@ interface HomeLandingProps {
 //   el router del sitio (buildFlowUrl de BRT-95), no un <a href> a
 //   https://brot74.com/?step=slots hardcodeado.
 // - Los typos heredados del copy original ("trasnferencia" ×2,
-//   "conuna") están corregidos.
+//   "conuna") están corregidos, así como los "¿" faltantes en
+//   "¿Por qué BROT 74?" y "¿Y el 74?".
 // - Las fotos van con next/image en vez de <img> planas.
 export default function HomeLanding({ onReservar }: HomeLandingProps) {
   return (
@@ -141,7 +142,7 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
           <div>
             <div className="rule block-rule"></div>
             <h2>
-              Por qué <span style={{ color: "#C8851A" }}>BROT 74?</span>
+              ¿Por qué <span style={{ color: "#C8851A" }}>BROT 74?</span>
             </h2>
             <dl className="day">
               <dd>
@@ -156,7 +157,7 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
               cotidiana, ese es Alemania.
             </p>
             <dl className="day">
-              <dt>Y el 74?</dt>
+              <dt>¿Y el 74?</dt>
               <dd>
                 Nuestra identidad está en ese número. 74% es la
                 hidratación de nuestra masa madre.


### PR DESCRIPTION
## Qué
Agrega los "¿" faltantes en dos títulos de la landing (BRT-136):
- "Por qué BROT 74?" → "¿Por qué BROT 74?"
- "Y el 74?" → "¿Y el 74?"

## Por qué
Heredados sin corregir desde `_design/design_cambios_v31/pantallas_actualizadas/landing.html` (líneas 99 y 102) al convertir el diseño a React. Detectado en la validación de typos post-BRT-136.

## Testing
- Verificado visualmente en localhost (ambos "¿" renderizan correctamente).
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing opening question marks in landing-page headings: “¿Por qué BROT 74?” and “¿Y el 74?”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->