### PR TITLE
fix: rail flotante en mobile (IG + Elegí tu BROT)

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -99,7 +99,14 @@
   .brot-landing .hero-card { position: relative; left: 0; right: 0; top: auto; bottom: auto; width: auto; max-width: none; margin: -72px clamp(16px, 4vw, 40px) 0; }
   .brot-landing .offset .media { width: 100%; margin-right: 0; margin-top: clamp(28px, 6vw, 56px); }
   .brot-landing .media.tall { margin-top: 0; }
-  .brot-landing .social { position: static; transform: none; flex-direction: row-reverse; align-items: center; justify-content: flex-start; gap: 14px; padding: 18px clamp(16px, 4vw, 40px) 0; }
+  /* El rail queda flotante también en mobile (igual que en desktop y que
+     la referencia tobrod.dk), no en flujo normal — probado en producción
+     con un usuario real: al pasar a position:static, el pill+IG solo se
+     veían pegados debajo del hero y desaparecían al seguir bajando, lo
+     cual se percibía como "se pierden" en vez de acompañar el scroll. */
+  .brot-landing .social { position: fixed; left: auto; right: clamp(16px, 4vw, 24px); top: auto; bottom: clamp(16px, 4vw, 24px); transform: none; flex-direction: row-reverse; align-items: center; justify-content: flex-end; gap: 12px; padding: 0; }
+  .brot-landing .social span,
+  .brot-landing .social .pill { box-shadow: 0 4px 14px rgba(14, 35, 60, .3); }
   .brot-landing .foot-flex { gap: 24px; }
 }
 @media (max-width: 520px) {

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -57,14 +57,12 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
         </div>
       </header>
 
-      {/* Rail: position:fixed en desktop (el orden en el DOM no importa,
-         se posiciona por viewport) — en ≤820px pasa a position:static y
-         ahí sí importa el orden: va DESPUÉS del hero en el markup para
-         que cuando deje de ser fijo caiga debajo de la foto, no arriba
-         (fix: en el HTML original del diseño el rail iba antes del
-         header y quedaba arriba de la foto en mobile, al revés de lo
-         que pide el propio ticket — "baja a fila horizontal debajo del
-         hero"). Ver HomeLanding.css. */}
+      {/* Rail: position:fixed tanto en desktop como en mobile (queda
+         flotante siempre visible mientras se scrollea, como en la
+         referencia tobrod.dk) — el orden en el DOM no importa porque
+         nunca pasa a position:static. El bloque va igual después del
+         hero en el markup (antes importaba para el fallback en flujo
+         que se probó y se descartó por UX). Ver HomeLanding.css. */}
       <div className="social">
         <a
           href="https://www.instagram.com/brot.74"


### PR DESCRIPTION
## Qué
En mobile (≤820px) el rail de Instagram + \"Elegí tu BROT\" pasa de `position: fixed` a `position: fixed` abajo a la derecha (antes: `static`), quedando flotante y siempre visible mientras se scrollea, igual que en desktop y que la referencia tobrod.dk.

## Por qué
Reporte de usuario real en producción (S26 Ultra, Chrome y Brave, confirmado con video): con `position: static` el rail solo se veía pegado debajo del hero y desaparecía al seguir bajando. Ese comportamiento coincidía con el texto original del ticket BRT-136 (\"baja a fila horizontal debajo del hero\"), pero no era lo esperado — se quiere un CTA persistente, no uno que se pierda.

Se verificó primero que no había ningún bug de layout/CSS (el `.social` seguía el scroll en perfecta sincronía, sin saltos) — el comportamiento estaba funcionando tal cual estaba escrito, solo que no era el deseado.

## Cambio
- `.brot-landing .social` en la media query ≤820px: `position: fixed`, anclado abajo a la derecha (`bottom`/`right` con `clamp`), con `box-shadow` en el ícono y el pill para despegarlos del contenido de fondo.

## Testing
- Verificado en localhost a 375px: el rail mantiene `position: fixed` en cualquier punto del scroll (0 a 1800px), sin superposiciones raras.
- Desktop sin cambios (`position: fixed` ya existía ahí).
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)