### PR TITLE
fix: en mobile la foto de ¿Por qué BROT 74? va después del texto

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -99,6 +99,11 @@
   .brot-landing .hero-card { position: relative; left: 0; right: 0; top: auto; bottom: auto; width: auto; max-width: none; margin: -72px clamp(16px, 4vw, 40px) 0; }
   .brot-landing .offset .media { width: 100%; margin-right: 0; margin-top: clamp(28px, 6vw, 56px); }
   .brot-landing .media.tall { margin-top: 0; }
+  /* Pedido explícito: en mobile la foto de "¿Por qué BROT 74?" va
+     después del texto de la sección ("Así de simple. Como el pan."),
+     no antes. Con order (no cambia el DOM) para no tocar el desktop,
+     donde esta misma foto sigue siendo la columna izquierda. */
+  .brot-landing .porque-media { order: 2; margin-top: clamp(28px, 6vw, 56px); }
   /* El rail queda flotante también en mobile (igual que en desktop y que
      la referencia tobrod.dk), no en flujo normal — probado en producción
      con un usuario real: al pasar a position:static, el pill+IG solo se

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -126,7 +126,12 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
       {/* Por qué BROT 74 */}
       <section className="wrap" style={{ paddingTop: "clamp(90px,13vh,190px)" }}>
         <div className="grid">
-          <div>
+          {/* porque-media: en mobile este bloque pasa a estar DESPUÉS del
+             texto ("order" de CSS Grid, ver HomeLanding.css) — pedido
+             explícito del usuario, la imagen va después de "Así de
+             simple. Como el pan." solo en mobile. En desktop no cambia
+             nada, sigue siendo la columna izquierda del grid. */}
+          <div className="porque-media">
             <div className="media" style={{ aspectRatio: "1 / 1.05", width: "72%" }}>
               <Image
                 src="/assets/landing-porque.webp"


### PR DESCRIPTION
## Qué
Solo en mobile (≤820px), la foto de la sección "¿Por qué BROT 74?" (`landing-porque.webp`) pasa a mostrarse **después** de "Así de simple. Como el pan." en vez de antes de todo el bloque de texto.

## Por qué
Pedido explícito del usuario.

## Cómo
`order: 2` de CSS Grid en el contenedor de la imagen (`.porque-media`), scopeado a la media query ≤820px. No se toca el DOM ni el desktop — ahí la foto sigue siendo la columna izquierda del grid de 2 columnas.

## Testing
- Verificado en localhost a 375px: la foto aparece después del párrafo final de la sección.
- Verificado en desktop (1280px): `order` computado es `0` (sin cambios), la foto sigue en su columna.
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Responsive Design**
  * On mobile devices, the “¿Por qué BROT 74?” photo now appears after the section text for a more natural reading flow.
  * Desktop layout remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->