### PR TITLE
fix: separación entre hero e Idea en mobile (bug de especificidad CSS)

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -99,6 +99,19 @@
   .brot-landing .hero-card { position: relative; left: 0; right: 0; top: auto; bottom: auto; width: auto; max-width: none; margin: -72px clamp(16px, 4vw, 40px) 0; }
   .brot-landing .offset .media { width: 100%; margin-right: 0; margin-top: clamp(28px, 6vw, 56px); }
   .brot-landing .media.tall { margin-top: 0; }
+  /* Bug real (no solo falta de "separación"): .brot-landing .wrap tiene
+     más clases que .brot-landing section, así que SIEMPRE le gana y
+     pisa el padding vertical a 0 — la regla ".brot-landing section"
+     de arriba nunca se aplica en ninguna sección con className="wrap".
+     Las otras 2 secciones no lo sufren porque tienen paddingTop inline
+     (mayor especificidad, gana siempre). En desktop no se nota porque
+     .hero-card es position:absolute (no ocupa espacio en el flujo); en
+     mobile pasa a estar en flujo y la sección "Idea" (sin paddingTop
+     inline) queda pegada contra la tarjeta del hero. Reponemos acá el
+     mismo valor que la regla muerta de arriba pretendía dar — solo
+     paddingTop, así no tocamos el padding horizontal de .wrap ni
+     pisamos el paddingTop inline que ya tienen las otras secciones. */
+  .brot-landing section.wrap { padding-top: clamp(56px, 9vh, 132px); }
   /* Pedido explícito: en mobile la foto de "¿Por qué BROT 74?" va
      después del texto de la sección ("Así de simple. Como el pan."),
      no antes. Con order (no cambia el DOM) para no tocar el desktop,


### PR DESCRIPTION
## Qué
En mobile la imagen de la sección "Idea" quedaba pegada directamente contra la tarjeta cream del hero, sin separación (reportado con captura por el usuario).

## Causa raíz
No era falta de "margen" — es un bug de especificidad CSS. `.brot-landing .wrap` (2 clases) siempre gana contra `.brot-landing section` (1 clase + elemento), así que la regla genérica que da padding vertical a las secciones (`section { padding: clamp(56px,9vh,132px) 0; }`) **nunca se aplicaba** en ninguna sección con `className="wrap"` — quedaban con padding vertical en `0`, salvo que tuvieran un `paddingTop` inline (como las otras 2 secciones de la landing).

En desktop no se notaba porque `.hero-card` es `position: absolute` (no ocupa espacio en el flujo del documento). En mobile pasa a estar en flujo, y ahí la sección "Idea" (la única de las 3 sin `paddingTop` inline) quedaba pegada contra el hero.

## Fix
`padding-top` explícito para `section.wrap` dentro de la media query ≤820px, con más especificidad que `.wrap` — solo afecta a las secciones que no tienen ya su propio `paddingTop` inline (las otras 2 quedan intactas, el inline sigue ganando).

## Testing
- Verificado en localhost a 375px: ~73px de separación entre la tarjeta del hero y la imagen de "Idea" (antes: 0px).
- Las otras 2 secciones (con `paddingTop` inline) no cambiaron: 105.56px y 64.96px, iguales a antes.
- Desktop sin cambios (fix scopeado a la media query ≤820px).
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing at the top of landing-page sections on smaller screens.
  * Preserved horizontal spacing and existing section-specific layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->