### PR TITLE
fix: ¿Y el 74? al tamaño del h2 y el número en ámbar

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -81,7 +81,9 @@
 .brot-landing .porque-media .media { aspect-ratio: 1 / 1.05; width: 72%; }
 .brot-landing .block-rule { margin-bottom: 30px; }
 .brot-landing .day { margin-bottom: 22px; }
-.brot-landing .day dt { font-weight: 500; margin-bottom: 2px; }
+/* Pedido explícito: "¿Y el 74?" al mismo tamaño que los h2 (ej. "¿Por
+   qué BROT 74?") — antes heredaba el font-size del body (15px). */
+.brot-landing .day dt { font-weight: 500; margin-bottom: 2px; font-size: clamp(24px, 2.2vw, 32px); }
 .brot-landing .day dd { margin: 0; max-width: 60ch; }
 
 /* footer */

--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -81,9 +81,10 @@
 .brot-landing .porque-media .media { aspect-ratio: 1 / 1.05; width: 72%; }
 .brot-landing .block-rule { margin-bottom: 30px; }
 .brot-landing .day { margin-bottom: 22px; }
-/* Pedido explícito: "¿Y el 74?" al mismo tamaño que los h2 (ej. "¿Por
-   qué BROT 74?") — antes heredaba el font-size del body (15px). */
-.brot-landing .day dt { font-weight: 500; margin-bottom: 2px; font-size: clamp(24px, 2.2vw, 32px); }
+/* Pedido explícito: "¿Y el 74?" al mismo tamaño y peso que los h2
+   (ej. "¿Por qué BROT 74?") — antes heredaba el font-size del body
+   (15px) y tenía font-weight:500 (se veía en negrita al agrandarlo). */
+.brot-landing .day dt { font-weight: 400; margin-bottom: 2px; font-size: clamp(24px, 2.2vw, 32px); }
 .brot-landing .day dd { margin: 0; max-width: 60ch; }
 
 /* footer */

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -165,7 +165,9 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
               cotidiana, ese es Alemania.
             </p>
             <dl className="day">
-              <dt>¿Y el 74?</dt>
+              <dt>
+                ¿Y el <span style={{ color: "#C8851A" }}>74</span>?
+              </dt>
               <dd>
                 Nuestra identidad está en ese número. 74% es la
                 hidratación de nuestra masa madre.


### PR DESCRIPTION
## Qué
El texto "¿Y el 74?" (sección "¿Por qué BROT 74?") pasa a tener el mismo tamaño de fuente que los `h2` de la landing, y el número "74" queda en color ámbar (`#C8851A`).

## Por qué
Pedido explícito.

## Testing
- Verificado en localhost: `font-size` de `.day dt` = 24px, igual al `h2` (24px en este viewport). Color del `span` con "74" = `rgb(200, 133, 26)` = `#C8851A`.
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)