### PR TITLE
fix: mover 'Horarios de entregas' del footer a Pedís hoy

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -89,6 +89,16 @@
 
 /* footer */
 .brot-landing footer { border-top: 1px solid var(--rule); padding: clamp(48px, 8vh, 110px) 0 clamp(40px, 6vh, 80px); }
+/* Mismo bug de especificidad que ya se arregló para las secciones
+   (ver la regla de section.wrap en la media query ≤820px): footer
+   también tiene className="wrap", y ".brot-landing .wrap" (2 clases)
+   le gana a ".brot-landing footer" (1 clase + elemento) y pisa su
+   padding vertical a 0 — la línea del border-top quedaba pegada
+   contra el contenido anterior. No se notaba antes porque el párrafo
+   de "Pedís hoy" tenía <br/> de relleno al final; se sacaron al mover
+   "Horarios de entregas" ahí y quedó expuesto. Reponemos acá el mismo
+   valor que la regla de arriba pretendía dar. */
+.brot-landing footer.wrap { padding-top: clamp(48px, 8vh, 110px); padding-bottom: clamp(40px, 6vh, 80px); }
 .brot-landing .foot-brand { font-size: clamp(22px, 2.4vw, 34px); letter-spacing: .02em; font-weight: 400; margin-bottom: 18px; }
 .brot-landing .foot-note { color: var(--stone); font-size: 14px; }
 .brot-landing .foot-col h3 { font-size: clamp(19px, 1.7vw, 25px); margin-bottom: 12px; }

--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -161,7 +161,6 @@
   .brot-landing .social { position: fixed; left: auto; right: clamp(16px, 4vw, 24px); top: auto; bottom: clamp(16px, 4vw, 24px); transform: none; flex-direction: row-reverse; align-items: center; justify-content: flex-end; gap: 12px; padding: 0; }
   .brot-landing .social span,
   .brot-landing .social .pill { box-shadow: 0 4px 14px rgba(14, 35, 60, .3); }
-  .brot-landing .foot-flex { gap: 24px; }
 }
 @media (max-width: 520px) {
   .brot-landing .hero-title { font-size: clamp(40px, 13vw, 64px); }

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -179,7 +179,14 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
       </section>
 
       {/* Pedís hoy, retirás cuando esté listo */}
-      <section className="wrap" style={{ paddingTop: "clamp(56px,8vh,110px)" }}>
+      {/* paddingBottom explícito: es la última sección antes del
+         footer, así que necesita su PROPIO aire abajo (las secciones
+         anteriores no lo necesitan porque la siguiente sección aporta
+         el espacio con su paddingTop). Mismo bug de especificidad de
+         siempre (.wrap le gana a section y pisa el padding vertical a
+         0) — sin esto la línea del footer queda pegada contra
+         "Horarios de entregas". */}
+      <section className="wrap" style={{ paddingTop: "clamp(56px,8vh,110px)", paddingBottom: "clamp(56px,9vh,132px)" }}>
         <div className="grid">
           <div>
             <div className="rule block-rule"></div>
@@ -230,14 +237,19 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
       {/* Footer */}
       <footer className="wrap" id="contacto">
         <div className="grid">
-          <div style={{ gridColumn: "1 / -1" }}>
+          {/* Pedido explícito: logo más chico y centrado junto con el
+             subtítulo "Micropanadería de Masa Madre" (antes: alineados
+             a la izquierda, logo más grande). textAlign:center en el
+             contenedor centra el <p> de texto; el logo (display:block)
+             necesita además su propio margin:auto para centrarse. */}
+          <div style={{ gridColumn: "1 / -1", textAlign: "center" }}>
             <div className="foot-brand" style={{ marginBottom: 0 }}>
               <Image
                 src="/assets/logo-sello-mono-navy-transparente.png"
                 alt="BROT 74"
                 width={2400}
                 height={2400}
-                style={{ width: "clamp(120px,14vw,180px)", height: "auto", display: "block", marginTop: "clamp(16px,3vw,40px)" }}
+                style={{ width: "clamp(80px,9vw,120px)", height: "auto", display: "block", margin: "clamp(16px,3vw,40px) auto 0" }}
               />
             </div>
             <div className="foot-note" style={{ marginTop: "18px" }}>

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -202,11 +202,24 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
               <br />
               Pasás a buscarlo en el lugar y la franja horaria de la
               fecha. Horneamos por tandas, no hay local abierto.
-              <br />
-              <br />
-              <br />
-              <br />
             </p>
+            {/* Pedido explícito: "Horarios de entregas" se movió acá desde
+               el footer, sin cambiar tamaño ni color — sigue siendo el
+               mismo bloque (className="foot-col", mismo style inline),
+               así que sigue matcheando la regla .foot-col h3 en CSS tal
+               cual estaba. Se sacaron los <br/> de relleno que tenía el
+               párrafo anterior (eran aire antes del footer; acá generaban
+               un salto raro antes de este bloque). */}
+            <div className="foot-col" style={{ marginTop: "clamp(16px,3vw,40px)" }}>
+              <h3>
+                Horarios de <span style={{ color: "#C8851A" }}>entregas</span>
+              </h3>
+              <p>
+                Miércoles: desde las 18:00 horas
+                <br />
+                Sábados: desde las 18:00 horas
+              </p>
+            </div>
           </div>
           <div></div>
         </div>
@@ -216,32 +229,14 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
       <footer className="wrap" id="contacto">
         <div className="grid">
           <div style={{ gridColumn: "1 / -1" }}>
-            <div
-              className="foot-flex"
-              style={{ display: "flex", flexWrap: "wrap", gap: "clamp(28px,5vw,80px)", alignItems: "center" }}
-            >
-              <div className="foot-brand" style={{ marginBottom: 0 }}>
-                <Image
-                  src="/assets/logo-sello-mono-navy-transparente.png"
-                  alt="BROT 74"
-                  width={2400}
-                  height={2400}
-                  style={{ width: "clamp(120px,14vw,180px)", height: "auto", display: "block", marginTop: "clamp(16px,3vw,40px)" }}
-                />
-              </div>
-              <div
-                className="foot-col"
-                style={{ marginTop: "clamp(16px,3vw,40px)", flex: "1 1 260px", minWidth: "min(100%,260px)" }}
-              >
-                <h3>
-                  Horarios de <span style={{ color: "#C8851A" }}>entregas</span>
-                </h3>
-                <p>
-                  Miércoles: desde las 18:00 horas
-                  <br />
-                  Sábados: desde las 18:00 horas
-                </p>
-              </div>
+            <div className="foot-brand" style={{ marginBottom: 0 }}>
+              <Image
+                src="/assets/logo-sello-mono-navy-transparente.png"
+                alt="BROT 74"
+                width={2400}
+                height={2400}
+                style={{ width: "clamp(120px,14vw,180px)", height: "auto", display: "block", marginTop: "clamp(16px,3vw,40px)" }}
+              />
             </div>
             <div className="foot-note" style={{ marginTop: "18px" }}>
               Micropanadería de Masa Madre


### PR DESCRIPTION
## Qué
El bloque "Horarios de entregas" (h3 + "Miércoles/Sábados desde las 18:00 horas") pasa de vivir en el footer a ser parte de la sección "Pedís hoy, retirás cuando esté listo", después del paso "3. Retirá en tu horario".

## Por qué
Pedido explícito, sin cambiar tamaño ni color.

## Cómo
Se movió el mismo bloque JSX (`className="foot-col"`, mismo `style` inline) tal cual estaba, así que sigue matcheando las mismas reglas CSS (`.foot-col h3` para el tamaño, `#C8851A` para "entregas") — no se tocó ningún valor de tipografía o color.

Efectos secundarios de la relocación:
- Se sacaron los 4 `<br/>` de relleno que tenía el párrafo "3. Retirá en tu horario..." (eran aire pensado para antes del footer; con el nuevo bloque justo después generaban un salto raro).
- El footer quedó con `.foot-flex` sin ningún hijo (solo tenía `foot-brand` + el `foot-col` que se movió) — se simplificó a dos divs sueltos y se sacó la regla `.foot-flex` de la media query mobile, que ya no se usa.

## Testing
- Verificado en localhost: el bloque está dentro de la sección "Pedís hoy" (no en el footer), con `h3` a 19px y el span de "entregas" en `rgb(200, 133, 26)` (`#C8851A`) — igual que antes.
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Moved the “Horarios de entregas” information into the order instructions section for better visibility.
  * Simplified the footer layout by removing the delivery-hours column and adjusting spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->