### PR TITLE
feat(BRT-139): detectar PRs de Dependabot con metadata de riesgo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "test:db:up": "docker compose -f docker-compose.test.yml up -d --wait",
     "test:db:down": "docker compose -f docker-compose.test.yml down",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "dependabot:detect": "tsx scripts/dependabot-triage/github.ts"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"

--- a/scripts/dependabot-triage/github.ts
+++ b/scripts/dependabot-triage/github.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, join } from "node:path";
 
 /**
  * BRT-139: detecta las PRs abiertas de Dependabot y extrae la metadata de
@@ -9,6 +11,35 @@ import { execFileSync } from "node:child_process";
  * resto del agente de triage (BRT-142, aprobar PRs) y ya viene autenticado
  * en el runner de GitHub Actions sin necesidad de credenciales propias.
  */
+
+/**
+ * Resuelve el path absoluto de un ejecutable buscando en las carpetas de
+ * `PATH`, en vez de pasarle el nombre pelado a `execFileSync` y dejar que
+ * el propio proceso hijo lo busque en el momento de ejecutarlo (Sonar
+ * S4036 / CWE-426, "Untrusted Search Path"). El binario resuelto se cachea
+ * por nombre para no recorrer `PATH` en cada llamada.
+ */
+const resolvedExecutables = new Map<string, string>();
+
+function resolveExecutable(name: string): string {
+  const cached = resolvedExecutables.get(name);
+  if (cached) return cached;
+
+  const candidates = process.platform === "win32" ? [`${name}.exe`, `${name}.cmd`] : [name];
+  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+
+  for (const dir of dirs) {
+    for (const candidate of candidates) {
+      const full = join(dir, candidate);
+      if (existsSync(full)) {
+        resolvedExecutables.set(name, full);
+        return full;
+      }
+    }
+  }
+
+  throw new Error(`No encontré "${name}" en el PATH del sistema.`);
+}
 
 export type BumpType = "major" | "minor" | "patch" | "unknown";
 
@@ -54,7 +85,7 @@ export function repoSlug(): string {
   if (fromEnv) return fromEnv;
 
   const remote = execFileSync(
-    "git",
+    resolveExecutable("git"),
     ["config", "--get", "remote.origin.url"],
     { encoding: "utf8" },
   ).trim();
@@ -66,7 +97,9 @@ export function repoSlug(): string {
 }
 
 function ghApi<T>(path: string): T {
-  const output = execFileSync("gh", ["api", path], { encoding: "utf8" });
+  const output = execFileSync(resolveExecutable("gh"), ["api", path], {
+    encoding: "utf8",
+  });
   return JSON.parse(output) as T;
 }
 
@@ -109,11 +142,6 @@ function severityForPackage(
   return severidades.sort((a, b) => SEVERITY_RANK[b] - SEVERITY_RANK[a])[0];
 }
 
-// Título de Dependabot: "Bump next from 16.3.0 to 16.3.1". Sin anclar al
-// inicio del string a propósito: este repo tiene conventional commits
-// activado, así que Dependabot antepone "chore(deps): " / "chore(deps-dev): ".
-const BUMP_TITLE_RE = /bump (\S+) from (\S+) to (\S+)/i;
-
 function parseVersionParts(version: string): [number, number, number] | null {
   const cleaned = version.replace(/^v/, "").split(/[-+]/)[0];
   const parts = cleaned.split(".").map(Number);
@@ -132,22 +160,50 @@ function bumpTypeFromVersions(desde: string, hasta: string): BumpType {
   return "unknown";
 }
 
+const UNKNOWN_BUMP = {
+  bumpType: "unknown" as const,
+  versionDesde: null,
+  versionHasta: null,
+};
+
+/**
+ * Parsea el título de Dependabot: "Bump next from 16.3.0 to 16.3.1". Este
+ * repo tiene conventional commits activado, así que Dependabot antepone
+ * "chore(deps): " / "chore(deps-dev): " — por eso se busca "bump " en
+ * cualquier posición del título en vez de anclar al inicio.
+ *
+ * Parseo manual con `indexOf`/`slice` en vez de un único regex con varios
+ * cuantificadores sin límite (evita el riesgo de backtracking súper-lineal
+ * que marca Sonar en ese patrón — acá no hace falta, son tres substrings
+ * separados por literales fijos).
+ */
 function parseBump(
   title: string,
 ): Pick<DependabotPrRisk, "paquete" | "bumpType" | "versionDesde" | "versionHasta"> {
-  const match = title.match(BUMP_TITLE_RE);
-  if (!match) {
-    // PR agrupada o título con formato no estándar (ej. dependabot.yml con
-    // `groups:` a futuro) — no podemos identificar el paquete ni el bump,
-    // el motor de clasificación (BRT-140) trata "unknown" como crítico.
-    return {
-      paquete: title,
-      bumpType: "unknown",
-      versionDesde: null,
-      versionHasta: null,
-    };
+  const lower = title.toLowerCase();
+  const bumpAt = lower.indexOf("bump ");
+  if (bumpAt === -1) {
+    return { paquete: title, ...UNKNOWN_BUMP };
   }
-  const [, paquete, versionDesde, versionHasta] = match;
+
+  const fromAt = lower.indexOf(" from ", bumpAt);
+  const toAt = fromAt === -1 ? -1 : lower.indexOf(" to ", fromAt);
+  if (fromAt === -1 || toAt === -1) {
+    return { paquete: title, ...UNKNOWN_BUMP };
+  }
+
+  const paquete = title.slice(bumpAt + "bump ".length, fromAt).trim();
+  const versionDesde = title.slice(fromAt + " from ".length, toAt).trim();
+  // Corta en el primer espacio para descartar sufijos tipo "in /apps/web"
+  // que Dependabot agrega en monorepos con varios `directory:`.
+  const resto = title.slice(toAt + " to ".length).trimStart();
+  const espacioAt = resto.indexOf(" ");
+  const versionHasta = espacioAt === -1 ? resto : resto.slice(0, espacioAt);
+
+  if (!paquete || !versionDesde || !versionHasta) {
+    return { paquete: title, ...UNKNOWN_BUMP };
+  }
+
   return {
     paquete,
     bumpType: bumpTypeFromVersions(versionDesde, versionHasta),

--- a/scripts/dependabot-triage/github.ts
+++ b/scripts/dependabot-triage/github.ts
@@ -1,0 +1,186 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * BRT-139: detecta las PRs abiertas de Dependabot y extrae la metadata de
+ * riesgo (paquete, tipo de bump, severidad del CVE si existe) que después
+ * consume el motor de clasificación (BRT-140) contra config/dependabot-risk.json.
+ *
+ * Usa el CLI `gh` en vez de octokit: es el mismo mecanismo que va a usar el
+ * resto del agente de triage (BRT-142, aprobar PRs) y ya viene autenticado
+ * en el runner de GitHub Actions sin necesidad de credenciales propias.
+ */
+
+export type BumpType = "major" | "minor" | "patch" | "unknown";
+
+export type SeverityLevel = "low" | "moderate" | "high" | "critical";
+
+const SEVERITY_RANK: Record<SeverityLevel, number> = {
+  low: 0,
+  moderate: 1,
+  high: 2,
+  critical: 3,
+};
+
+export interface DependabotPrRisk {
+  numero: number;
+  titulo: string;
+  url: string;
+  paquete: string;
+  bumpType: BumpType;
+  versionDesde: string | null;
+  versionHasta: string | null;
+  severidad?: SeverityLevel;
+}
+
+interface GitHubPullRequest {
+  number: number;
+  title: string;
+  html_url: string;
+  user: { login: string; type: string } | null;
+}
+
+interface DependabotAlert {
+  state: string;
+  security_advisory: { severity: string };
+  dependency: { package: { name: string } };
+}
+
+/**
+ * Resuelve "owner/repo". En GitHub Actions viene en `GITHUB_REPOSITORY`;
+ * corriendo el script a mano lo saca del remote de git.
+ */
+export function repoSlug(): string {
+  const fromEnv = process.env.GITHUB_REPOSITORY;
+  if (fromEnv) return fromEnv;
+
+  const remote = execFileSync(
+    "git",
+    ["config", "--get", "remote.origin.url"],
+    { encoding: "utf8" },
+  ).trim();
+  const match = remote.match(/[:/]([^/]+\/[^/]+?)(\.git)?$/);
+  if (!match) {
+    throw new Error(`No pude determinar owner/repo desde el remote: ${remote}`);
+  }
+  return match[1];
+}
+
+function ghApi<T>(path: string): T {
+  const output = execFileSync("gh", ["api", path], { encoding: "utf8" });
+  return JSON.parse(output) as T;
+}
+
+function listOpenDependabotPRs(owner: string, repo: string): GitHubPullRequest[] {
+  const prs = ghApi<GitHubPullRequest[]>(
+    `repos/${owner}/${repo}/pulls?state=open&per_page=100`,
+  );
+  return prs.filter((pr) => pr.user?.login === "dependabot[bot]");
+}
+
+/**
+ * Lee las Dependabot Alerts abiertas del repo para cruzar severidad por
+ * paquete. No es fatal si falla (repo sin alerts habilitadas, token sin el
+ * scope `security_events`): el resto del triage sigue sin severidad.
+ */
+function listOpenDependabotAlerts(owner: string, repo: string): DependabotAlert[] {
+  try {
+    return ghApi<DependabotAlert[]>(
+      `repos/${owner}/${repo}/dependabot/alerts?state=open&per_page=100`,
+    );
+  } catch (err) {
+    console.warn(
+      "No se pudieron leer Dependabot Alerts (se sigue sin severidad):",
+      (err as Error).message,
+    );
+    return [];
+  }
+}
+
+function severityForPackage(
+  alerts: DependabotAlert[],
+  paquete: string,
+): SeverityLevel | undefined {
+  const severidades = alerts
+    .filter((a) => a.dependency?.package?.name === paquete)
+    .map((a) => a.security_advisory?.severity as SeverityLevel)
+    .filter((s): s is SeverityLevel => s in SEVERITY_RANK);
+
+  if (severidades.length === 0) return undefined;
+  return severidades.sort((a, b) => SEVERITY_RANK[b] - SEVERITY_RANK[a])[0];
+}
+
+// Título de Dependabot: "Bump next from 16.3.0 to 16.3.1". Sin anclar al
+// inicio del string a propósito: este repo tiene conventional commits
+// activado, así que Dependabot antepone "chore(deps): " / "chore(deps-dev): ".
+const BUMP_TITLE_RE = /bump (\S+) from (\S+) to (\S+)/i;
+
+function parseVersionParts(version: string): [number, number, number] | null {
+  const cleaned = version.replace(/^v/, "").split(/[-+]/)[0];
+  const parts = cleaned.split(".").map(Number);
+  if (parts.length < 2 || parts.some((n) => Number.isNaN(n))) return null;
+  const [major, minor = 0, patch = 0] = parts;
+  return [major, minor, patch];
+}
+
+function bumpTypeFromVersions(desde: string, hasta: string): BumpType {
+  const from = parseVersionParts(desde);
+  const to = parseVersionParts(hasta);
+  if (!from || !to) return "unknown";
+  if (to[0] !== from[0]) return "major";
+  if (to[1] !== from[1]) return "minor";
+  if (to[2] !== from[2]) return "patch";
+  return "unknown";
+}
+
+function parseBump(
+  title: string,
+): Pick<DependabotPrRisk, "paquete" | "bumpType" | "versionDesde" | "versionHasta"> {
+  const match = title.match(BUMP_TITLE_RE);
+  if (!match) {
+    // PR agrupada o título con formato no estándar (ej. dependabot.yml con
+    // `groups:` a futuro) — no podemos identificar el paquete ni el bump,
+    // el motor de clasificación (BRT-140) trata "unknown" como crítico.
+    return {
+      paquete: title,
+      bumpType: "unknown",
+      versionDesde: null,
+      versionHasta: null,
+    };
+  }
+  const [, paquete, versionDesde, versionHasta] = match;
+  return {
+    paquete,
+    bumpType: bumpTypeFromVersions(versionDesde, versionHasta),
+    versionDesde,
+    versionHasta,
+  };
+}
+
+/**
+ * Punto de entrada del módulo: lista las PRs abiertas de Dependabot con su
+ * metadata de riesgo lista para que BRT-140 la clasifique.
+ */
+export function getOpenDependabotPRsWithRisk(): DependabotPrRisk[] {
+  const slug = repoSlug();
+  const [owner, repo] = slug.split("/");
+  const prs = listOpenDependabotPRs(owner, repo);
+  const alerts = listOpenDependabotAlerts(owner, repo);
+
+  return prs.map((pr) => {
+    const bump = parseBump(pr.title);
+    return {
+      numero: pr.number,
+      titulo: pr.title,
+      url: pr.html_url,
+      severidad: severityForPackage(alerts, bump.paquete),
+      ...bump,
+    };
+  });
+}
+
+// Permite correrlo a mano: `npx tsx scripts/dependabot-triage/github.ts`
+// (requiere `gh auth login` hecho localmente).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const prs = getOpenDependabotPRsWithRisk();
+  console.log(JSON.stringify(prs, null, 2));
+}


### PR DESCRIPTION
## Qué

Agrega [scripts/dependabot-triage/github.ts](scripts/dependabot-triage/github.ts): detecta las PRs abiertas de `dependabot[bot]` en el repo y extrae paquete, versión origen/destino, tipo de bump (major/minor/patch) y severidad del CVE asociado (Dependabot Alerts) cuando existe. Es la primera pieza del agente de triage ([BRT-137](https://brot74.atlassian.net/browse/BRT-137)) — la consume el motor de clasificación (BRT-140).

Usa el CLI `gh` (no octokit): mismo mecanismo que va a usar el resto del agente para aprobar PRs (BRT-142), ya autenticado en el runner de Actions sin credenciales propias.

Suma `npm run dependabot:detect` para correrlo a mano.

## Verificación en vivo

Lo corrí contra `gastton/brot74-web` real (10 PRs abiertas de Dependabot hoy). Encontró un bug real en el primer intento: el regex de parseo asumía títulos `"Bump X from A to B"` sin prefijo, pero este repo tiene conventional commits activado y Dependabot antepone `"chore(deps): "` / `"chore(deps-dev): "` — lo corregí (regex sin anclar al inicio) y volví a correrlo. Output final:

- `@prisma/client` 5.22.0→7.10.0, `prisma` 5.22.0→7.10.0 y `eslint` 9.39.4→10.9.1 → `bumpType: "major"`.
- `browserslist` 4.28.2→4.28.9 → `severidad: "high"` (una de las 2 vulnerabilidades que reportó GitHub al pushear).
- El resto → minor/patch sin severidad asociada.

Con esto quedan cubiertos los 3 criterios de aceptación de la historia: PRs reales con metadata correcta, 0 PRs no rompe (`prs.map` sobre array vacío), y PR sin alerta asociada no rompe (`severidad` queda `undefined`).

## Testing

No es un endpoint de `app/api/**`, así que no aplica el test de integración obligatorio de AGENTS.md. Verificación: `npx tsc --noEmit` limpio, `npm run lint` sin errores (2 warnings de `security/detect-object-injection` en un `sort` con acceso a índice tipado — mismo patrón ya aceptado en el resto del repo), y corrida real documentada arriba.

## Fuera de alcance

Clasificación de riesgo (BRT-140), cualquier acción sobre las PRs (BRT-142), Jira/Slack (BRT-143/144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-137]: https://brot74.atlassian.net/browse/BRT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ