### PR TITLE
feat(BRT-141): workflow de GitHub Actions con cron diario

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -1,0 +1,44 @@
+name: Dependabot Triage Agent
+
+# BRT-141: agente de triage de PRs de Dependabot (BRT-137). Separado de
+# test.yml a propósito: no es CI de la app, es un proceso de mantenimiento
+# del repo. Corre en cron todos los días y se puede disparar a mano.
+#
+# Hoy solo detecta + clasifica (BRT-139/BRT-140) y deja un resumen — todavía
+# no aprueba PRs (Nivel 1: BRT-142) ni toca Jira/Slack (BRT-143/BRT-144).
+# Cuando esas historias se implementen, este workflow no necesita cambios:
+# solo va a hacer más el mismo `npm run dependabot:triage`.
+
+on:
+  schedule:
+    # 12:00 UTC = 09:00 en Argentina (UTC-3 todo el año, sin horario de verano).
+    - cron: "0 12 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: dependabot-triage
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  # Necesario para leer Dependabot Alerts (severidad de CVE) vía `gh api`.
+  security-events: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Detectar y clasificar PRs de Dependabot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run dependabot:triage

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -36,7 +36,11 @@ jobs:
           node-version: 20
           cache: npm
 
-      - run: npm ci
+      # --ignore-scripts: este job no necesita nada de lo que instalan los
+      # postinstall de prisma/sharp/playwright (no corre build ni Prisma) —
+      # evita ejecutar lifecycle scripts de terceros en un workflow que
+      # justamente existe para manejar riesgo de dependencias.
+      - run: npm ci --ignore-scripts
 
       - name: Detectar y clasificar PRs de Dependabot
         env:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:db:down": "docker compose -f docker-compose.test.yml down",
     "test:e2e": "playwright test",
     "dependabot:detect": "tsx scripts/dependabot-triage/github.ts",
-    "dependabot:classify": "tsx scripts/dependabot-triage/risk.ts"
+    "dependabot:classify": "tsx scripts/dependabot-triage/risk.ts",
+    "dependabot:triage": "tsx scripts/dependabot-triage/index.ts"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"

--- a/scripts/dependabot-triage/index.ts
+++ b/scripts/dependabot-triage/index.ts
@@ -1,0 +1,56 @@
+import { appendFileSync } from "node:fs";
+import { classifyDependabotPRs } from "./risk.js";
+import type { DependabotPrRisk } from "./github.js";
+
+/**
+ * BRT-141: entrypoint que corre el workflow de GitHub Actions
+ * (.github/workflows/dependabot-triage.yml).
+ *
+ * Hoy solo detecta (BRT-139) + clasifica (BRT-140) y deja un resumen en el
+ * job summary de Actions — todavía NO actúa sobre las PRs (Nivel 1:
+ * BRT-142) ni gestiona tickets de Jira o Slack (BRT-143/BRT-144). Ese
+ * trabajo se suma acá mismo a medida que esas historias se implementen.
+ */
+
+type PrClasificada = DependabotPrRisk & { critica: boolean; motivo: string };
+
+function resumenMarkdown(clasificadas: PrClasificada[]): string {
+  if (clasificadas.length === 0) {
+    return "## 🤖 Triage de Dependabot\n\nNo hay PRs abiertas de Dependabot hoy.\n";
+  }
+
+  const criticas = clasificadas.filter((pr) => pr.critica).length;
+
+  const filas = clasificadas
+    .map((pr) => {
+      const estado = pr.critica ? "🔴 crítica" : "🟢 no crítica";
+      return `| [#${pr.numero}](${pr.url}) | \`${pr.paquete}\` | ${pr.bumpType} | ${pr.severidad ?? "-"} | ${estado} | ${pr.motivo} |`;
+    })
+    .join("\n");
+
+  return [
+    "## 🤖 Triage de Dependabot",
+    "",
+    `${clasificadas.length} PR(s) abierta(s) — ${criticas} crítica(s).`,
+    "",
+    "| PR | Paquete | Bump | Severidad | Estado | Motivo |",
+    "|---|---|---|---|---|---|",
+    filas,
+    "",
+    "_Nivel 1 (aprobación automática) y la gestión de tickets/Slack todavía no están" +
+      " implementados — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
+  ].join("\n");
+}
+
+function main(): void {
+  const clasificadas = classifyDependabotPRs();
+
+  console.log(JSON.stringify(clasificadas, null, 2));
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    appendFileSync(summaryPath, resumenMarkdown(clasificadas));
+  }
+}
+
+main();


### PR DESCRIPTION
## Qué

Agrega [.github/workflows/dependabot-triage.yml](.github/workflows/dependabot-triage.yml): corre el agente de triage de Dependabot ([BRT-137](https://brot74.atlassian.net/browse/BRT-137)) todos los días, separado de `test.yml` a propósito (no es CI de la app, es mantenimiento del repo).

- Trigger: `schedule` (`0 12 * * *` = 09:00 Argentina) + `workflow_dispatch` para correrlo a mano.
- Permisos mínimos: `contents: read`, `pull-requests: write` (para BRT-142 a futuro), `security-events: read` (para leer Dependabot Alerts).
- `concurrency` evita corridas superpuestas si se dispara a mano mientras el cron está corriendo.

Suma [scripts/dependabot-triage/index.ts](scripts/dependabot-triage/index.ts), el entrypoint que ejecuta el workflow: hoy detecta (BRT-139) + clasifica (BRT-140) y deja un resumen en el job summary de Actions. **Todavía no aprueba PRs (Nivel 1: BRT-142) ni toca Jira/Slack (BRT-143/BRT-144)** — ese trabajo se suma acá mismo cuando esas historias se implementen, sin tocar el workflow.

## Por qué el scope quedó así

El ticket menciona wiring de secrets de Jira/Slack, pero ese código todavía no existe (BRT-143/BRT-144 son historias separadas más adelante) — agregar esos secrets ahora sería wiring sin nada que los consuma. Se van a sumar cuando esas historias lo necesiten.

## Verificación

`GITHUB_STEP_SUMMARY` simulado localmente contra las PRs reales del repo (10 PRs, 5 críticas hoy) — el resumen sale correcto en Markdown con links a cada PR.

**Nota sobre el criterio de aceptación de correr `workflow_dispatch` antes de habilitar el cron**: GitHub no permite disparar `workflow_dispatch` en una rama hasta que el archivo del workflow exista en la rama default (limitación de la plataforma) — devuelve 404 al intentarlo contra este PR. Voy a mergear y correrlo a mano una vez en `main` para validar, antes de que corra el cron real (próxima corrida programada recién mañana 09:00 ART).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-137]: https://brot74.atlassian.net/browse/BRT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ