### PR TITLE
feat(BRT-147): token dedicado opcional para leer Dependabot Alerts

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -22,7 +22,9 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  # Necesario para leer Dependabot Alerts (severidad de CVE) vía `gh api`.
+  # No alcanza para leer Dependabot Alerts (ver DEPENDABOT_ALERTS_TOKEN más
+  # abajo — BRT-147, confirmado con 403 en corrida real de BRT-141), pero se
+  # deja igual: es el permiso de menor privilegio correcto para lo demás.
   security-events: read
 
 jobs:
@@ -45,4 +47,8 @@ jobs:
       - name: Detectar y clasificar PRs de Dependabot
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # BRT-147: PAT propio con permiso de lectura de Dependabot Alerts
+          # (el GITHUB_TOKEN default no puede leer ese endpoint). Optativo:
+          # si el secret no existe, el paso sigue andando sin severidad.
+          DEPENDABOT_ALERTS_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
         run: npm run dependabot:triage

--- a/scripts/dependabot-triage/github.ts
+++ b/scripts/dependabot-triage/github.ts
@@ -96,9 +96,12 @@ export function repoSlug(): string {
   return match[1];
 }
 
-function ghApi<T>(path: string): T {
+function ghApi<T>(path: string, token?: string): T {
   const output = execFileSync(resolveExecutable("gh"), ["api", path], {
     encoding: "utf8",
+    // Sin `token`, hereda el auth de `gh` tal cual (GITHUB_TOKEN del
+    // workflow, o la sesión de `gh auth login` local).
+    env: token ? { ...process.env, GH_TOKEN: token } : process.env,
   });
   return JSON.parse(output) as T;
 }
@@ -112,13 +115,21 @@ function listOpenDependabotPRs(owner: string, repo: string): GitHubPullRequest[]
 
 /**
  * Lee las Dependabot Alerts abiertas del repo para cruzar severidad por
- * paquete. No es fatal si falla (repo sin alerts habilitadas, token sin el
- * scope `security_events`): el resto del triage sigue sin severidad.
+ * paquete. No es fatal si falla (repo sin alerts habilitadas, token sin
+ * permiso): el resto del triage sigue sin severidad.
+ *
+ * BRT-147: este endpoint específico no acepta el `GITHUB_TOKEN` default de
+ * un workflow bajo ningún permiso (403 "Resource not accessible by
+ * integration", confirmado en corrida real de BRT-141) — hace falta un PAT
+ * propio con permiso de lectura de Dependabot Alerts. Si existe la env var
+ * `DEPENDABOT_ALERTS_TOKEN` se usa esa para esta llamada puntual; el resto
+ * del script (listar/aprobar PRs) sigue con el token default de `gh`.
  */
 function listOpenDependabotAlerts(owner: string, repo: string): DependabotAlert[] {
   try {
     return ghApi<DependabotAlert[]>(
       `repos/${owner}/${repo}/dependabot/alerts?state=open&per_page=100`,
+      process.env.DEPENDABOT_ALERTS_TOKEN,
     );
   } catch (err) {
     console.warn(


### PR DESCRIPTION
## Qué

El `GITHUB_TOKEN` default de un workflow no puede leer `GET /repos/:owner/:repo/dependabot/alerts` bajo ningún permiso (`403 Resource not accessible by integration`, confirmado en la [corrida real de BRT-141](https://github.com/gastton/brot74-web/actions/runs/34365716694)) — GitHub requiere ahí un PAT propio.

`ghApi()` en [github.ts](scripts/dependabot-triage/github.ts) ahora acepta un token opcional que sobreescribe `GH_TOKEN` solo para esa llamada puntual. `listOpenDependabotAlerts()` lo usa si existe la env var `DEPENDABOT_ALERTS_TOKEN`; el resto del script (listar PRs, y a futuro aprobar — BRT-142) sigue con el token default de `gh`. El workflow pasa `secrets.DEPENDABOT_ALERTS_TOKEN` (optativo) a ese paso.

## Verificación

- Sin token seteado: mismo comportamiento que antes del cambio (corrido en vivo, 10 PRs, 1 con severidad gracias a que mi sesión local de `gh` sí tiene scope suficiente).
- Con un token inválido a propósito: confirma que el override se usa de verdad (pasa de `403` a `401 Bad credentials`) y el fallback sigue sin romper la corrida.

## Lo que falta (fuera de este PR, es acción manual en GitHub)

1. Crear un fine-grained PAT en GitHub con permiso de repo **"Dependabot alerts: Read-only"**, scopeado solo a `brot74-web`.
2. Guardarlo como secret del repo — **desde tu terminal, no pegándomelo a mí**, para que el token no quede en ningún lado del chat:
   ```
   gh secret set DEPENDABOT_ALERTS_TOKEN --repo gastton/brot74-web
   ```
   (`gh` pide pegarlo con input oculto).
3. Listo — la próxima corrida del cron (o un `workflow_dispatch` manual) ya lo va a usar solo.

## Fuera de alcance

Nivel 1, Jira, Slack — historias separadas de [BRT-137](https://brot74.atlassian.net/browse/BRT-137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-137]: https://brot74.atlassian.net/browse/BRT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependabot triage can now read alert severity when a dedicated access token is configured.
  * Triage continues without severity information when the optional token is unavailable.
  * Improved handling of authentication for Dependabot alert retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->