### PR TITLE
feat: aplicar entrega de diseño v32 (acentos ámbar + spacing)

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -102,7 +102,10 @@
 .brot-landing .foot-brand { font-size: clamp(22px, 2.4vw, 34px); letter-spacing: .02em; font-weight: 400; margin-bottom: 18px; }
 .brot-landing .foot-note { color: var(--stone); font-size: 14px; }
 .brot-landing .foot-col h3 { font-size: clamp(19px, 1.7vw, 25px); margin-bottom: 12px; }
-.brot-landing .foot-col ul { margin: 0; padding-left: 1.2em; }
+/* list-style-type: disc explícito porque el preflight de Tailwind
+   saca el bullet por default (list-style-type: none) — sin esto no
+   hay viñeta que colorear con ::marker más abajo. */
+.brot-landing .foot-col ul { margin: 0; padding-left: 1.2em; list-style-type: disc; }
 .brot-landing .foot-col li { margin: 0 0 4px; }
 .brot-landing .foot-col li::marker { color: var(--amber); }
 .brot-landing .foot-col + .foot-col { margin-top: 40px; }

--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -74,7 +74,7 @@
 .brot-landing .media { position: relative; aspect-ratio: 1 / 1; width: 100%; }
 .brot-landing .media.tall { aspect-ratio: 574 / 704; margin-top: clamp(24px, 4vw, 64px); }
 .brot-landing .offset { align-self: center; }
-.brot-landing .offset .media { aspect-ratio: 16 / 26; width: 78%; margin-right: 0; margin-left: auto; margin-top: clamp(64px, 10vw, 180px); }
+.brot-landing .offset .media { aspect-ratio: 16 / 26; width: 78%; margin-right: 0; margin-left: auto; margin-top: clamp(64px, 10vw, 180px); transform: translateY(clamp(24px, 4vw, 72px)); }
 /* antes inline en el JSX (style={{aspectRatio, width}}) — se movió acá
    porque un estilo inline le gana en especificidad a cualquier regla de
    CSS, y hubiera bloqueado el override de .media-bleed en mobile. */
@@ -102,6 +102,9 @@
 .brot-landing .foot-brand { font-size: clamp(22px, 2.4vw, 34px); letter-spacing: .02em; font-weight: 400; margin-bottom: 18px; }
 .brot-landing .foot-note { color: var(--stone); font-size: 14px; }
 .brot-landing .foot-col h3 { font-size: clamp(19px, 1.7vw, 25px); margin-bottom: 12px; }
+.brot-landing .foot-col ul { margin: 0; padding-left: 1.2em; }
+.brot-landing .foot-col li { margin: 0 0 4px; }
+.brot-landing .foot-col li::marker { color: var(--amber); }
 .brot-landing .foot-col + .foot-col { margin-top: 40px; }
 .brot-landing .legal { margin-top: clamp(48px, 7vh, 96px); display: flex; flex-wrap: wrap; gap: 8px 28px; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: var(--stone); }
 

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -46,7 +46,7 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
           </div>
           <div
             style={{
-              fontSize: "14px",
+              fontSize: "12px",
               letterSpacing: "1.76px",
               textTransform: "uppercase",
               marginBottom: "clamp(20px,6vh,72px)",
@@ -166,7 +166,7 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
             </p>
             <dl className="day">
               <dt>
-                ¿Y el <span style={{ color: "#C8851A" }}>74</span>?
+                ¿Y el <span style={{ color: "#C8851A" }}>74?</span>
               </dt>
               <dd>
                 Nuestra identidad está en ese número. 74% es la
@@ -191,8 +191,8 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
           <div>
             <div className="rule block-rule"></div>
             <h2>
-              Pedís hoy, retirás cuando{" "}
-              <span style={{ color: "#C8851A" }}>esté listo</span>
+              Pedís hoy,{" "}
+              <span style={{ color: "#C8851A" }}>retirás cuando esté listo</span>
             </h2>
             <p>
               1. Elegí tu BROT
@@ -221,13 +221,12 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
                un salto raro antes de este bloque). */}
             <div className="foot-col" style={{ marginTop: "clamp(16px,3vw,40px)" }}>
               <h3>
-                Horarios de <span style={{ color: "#C8851A" }}>entregas</span>
+                Horarios <span style={{ color: "#C8851A" }}>de entregas</span>
               </h3>
-              <p>
-                Miércoles: desde las 18:00 horas
-                <br />
-                Sábados: desde las 18:00 horas
-              </p>
+              <ul>
+                <li>Miércoles: desde las 18:00 horas</li>
+                <li>Sábados: desde las 18:00 horas</li>
+              </ul>
             </div>
           </div>
           <div></div>


### PR DESCRIPTION
## Qué
Aplica la entrega de diseño v32 (`_design/design_cambios_v32/`, depende de v31/BRT-136 ya aplicada): los 7 `patch_ops` de su `manifest.json` sobre `components/home/HomeLanding.tsx` y `HomeLanding.css`.

## Cambios
- Bajada del hero: 14px → 12px.
- "¿Y el 74?": el "?" entra en el ámbar junto al 74.
- "Pedís hoy, retirás cuando esté listo": el ámbar arranca en "retirás" (antes solo desde "esté listo").
- "Horarios de entregas": el ámbar arranca en "de".
- Horarios: de `<p>` con `<br/>` a `<ul><li>`, con viñeta ámbar (`::marker`).
- Foto vertical de "Idea" (columna offset) un poco más abajo — `transform: translateY(...)` en vez de `margin-top`, a propósito: no mueve nada de lo que está debajo.

Sin assets nuevos (los 5 de `pantallas_actualizadas/assets/` son idénticos a v31, no se pisaron) y sin tocar nada de lo que se ajustó después de v31 en este repo (ancho de la hero-card, "Horarios de entregas" en la sección de pedidos, footer centrado, comportamiento mobile) — el manifest lo señala explícitamente y los patches no tocan esas zonas.

## Testing
- Los 7 `find` de `patch_ops` matchearon exacto y una sola vez antes de aplicar (verificado por script antes de tocar los archivos).
- Verificado en localhost (desktop 1280px): tamaño de bajada 12px, spans en ámbar como se pide, lista con 2 `<li>` y viñeta ámbar, foto de "Idea" con `translateY(51.2px)`.
- Verificado en mobile (375px): la foto de "Idea" sigue a sangre (`left:0, width:375`) y ahora también con el `translateY` aplicado, sin scroll horizontal.
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)