### PR TITLE
feat: aplicar entrega de diseño v33 (footer más arriba)

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -96,9 +96,12 @@
    padding vertical a 0 — la línea del border-top quedaba pegada
    contra el contenido anterior. No se notaba antes porque el párrafo
    de "Pedís hoy" tenía <br/> de relleno al final; se sacaron al mover
-   "Horarios de entregas" ahí y quedó expuesto. Reponemos acá el mismo
-   valor que la regla de arriba pretendía dar. */
-.brot-landing footer.wrap { padding-top: clamp(48px, 8vh, 110px); padding-bottom: clamp(40px, 6vh, 80px); }
+   "Horarios de entregas" ahí y quedó expuesto. En principio se repuso
+   acá el mismo valor que la regla de arriba pretendía dar; v33 lo
+   redujo a propósito (110px → 52px) para subir el sello + "Micropanadería
+   de Masa Madre" — ya no matchea el valor de la regla muerta de
+   arriba, es deliberado. */
+.brot-landing footer.wrap { padding-top: clamp(24px, 4vh, 52px); padding-bottom: clamp(40px, 6vh, 80px); }
 .brot-landing .foot-brand { font-size: clamp(22px, 2.4vw, 34px); letter-spacing: .02em; font-weight: 400; margin-bottom: 18px; }
 .brot-landing .foot-note { color: var(--stone); font-size: 14px; }
 .brot-landing .foot-col h3 { font-size: clamp(19px, 1.7vw, 25px); margin-bottom: 12px; }

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -248,7 +248,7 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
                 alt="BROT 74"
                 width={2400}
                 height={2400}
-                style={{ width: "clamp(80px,9vw,120px)", height: "auto", display: "block", margin: "clamp(16px,3vw,40px) auto 0" }}
+                style={{ width: "clamp(80px,9vw,120px)", height: "auto", display: "block", margin: "0 auto" }}
               />
             </div>
             <div className="foot-note" style={{ marginTop: "18px" }}>


### PR DESCRIPTION
## Qué
Aplica la entrega de diseño v33 (`_design/design_cambios_v33/`, depende de v31/BRT-136 y v32, ya aplicadas): los 2 `patch_ops` de su `manifest.json` sobre `HomeLanding.css` y `HomeLanding.tsx`.

## Cambios
Solo spacing, sin copy/color/assets nuevos:
- `footer.wrap` `padding-top`: `clamp(48px,8vh,110px)` → `clamp(24px,4vh,52px)` (`padding-bottom` sin cambios).
- Logo del footer: pierde su `margin-top` (`clamp(16px,3vw,40px)` → `0`) — sigue centrado (`margin: 0 auto`) y con el mismo tamaño.

Efecto: el sello + "Micropanadería de Masa Madre" suben ~98px en desktop ancho y ~40px en pantallas chicas (según el propio manifest).

## Testing
- Los 2 `find` de `patch_ops` matchearon exacto y una sola vez antes de aplicar.
- Verificado en localhost (1280px): `padding-top` del footer = 36px (antes 88px), `margin-top` del logo = 0px, `padding-bottom` sin cambios (54px).
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced vertical spacing above the landing page footer.
  * Removed extra top spacing from the footer logo while preserving its responsive sizing and centered alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->