### PR TITLE
fix: foto de retiro también a sangre en mobile

### DIFF
--- a/components/home/HomeLanding.css
+++ b/components/home/HomeLanding.css
@@ -163,9 +163,13 @@
      .media-bleed es una utility class que tiene que ganarle sí o sí al
      ancho/margin contextual de cada foto (ej. ".offset .media" define
      margin-left:auto con más especificidad — sin !important quedaba
-     desplazada fuera de pantalla en vez de a sangre). */
+     desplazada fuera de pantalla en vez de a sangre). max-width
+     también !important: .retiro-media (v34) trae max-width:100% para
+     acotarla en desktop, y sin esto el ancho quedaba capado al de su
+     columna (335px) en vez de los 100vw pedidos. */
   .brot-landing .media-bleed {
     width: 100vw !important;
+    max-width: 100vw !important;
     position: relative;
     left: 50% !important;
     margin-left: -50vw !important;
@@ -188,7 +192,12 @@
      no antes. Con order (no cambia el DOM) para no tocar el desktop,
      donde esta misma foto sigue siendo la columna izquierda. */
   .brot-landing .porque-media { order: 2; margin-top: clamp(28px, 6vw, 56px); }
-  .brot-landing .retiro-media { width: 72%; margin: clamp(28px, 7vw, 56px) auto 0; transform: none; }
+  /* Pedido explícito: esta foto también va a sangre en mobile (antes
+     iba contenida al 72%, centrada) — el ancho/centrado horizontal
+     ahora lo maneja .media-bleed (agregada en el JSX). transform:none
+     se mantiene: sin el desplazamiento óptico que sí tiene en
+     desktop. */
+  .brot-landing .retiro-media { margin-top: clamp(28px, 7vw, 56px); transform: none; }
   /* El rail queda flotante también en mobile (igual que en desktop y que
      la referencia tobrod.dk), no en flujo normal — probado en producción
      con un usuario real: al pasar a position:static, el pill+IG solo se

--- a/components/home/HomeLanding.tsx
+++ b/components/home/HomeLanding.tsx
@@ -237,13 +237,17 @@ export default function HomeLanding({ onReservar }: HomeLandingProps) {
             </div>
           </div>
           <div className="retiro-col">
-            <div className="media retiro-media">
+            {/* media-bleed: pedido explícito, SOLO en mobile esta foto
+               también va a sangre (de punta a punta), igual que las de
+               "Idea" y "¿Por qué BROT 74?". Desktop no se toca — ahí
+               sigue a su tamaño real (481px). Ver HomeLanding.css. */}
+            <div className="media retiro-media media-bleed">
               <Image
                 src="/assets/landing-retiro.png"
                 alt="Bolsa kraft con panes lista para retirar"
                 fill
                 style={{ objectFit: "cover" }}
-                sizes="(min-width: 820px) 481px, 72vw"
+                sizes="(min-width: 820px) 481px, 100vw"
               />
             </div>
           </div>


### PR DESCRIPTION
## Qué
Solo en mobile, la foto de la bolsa kraft (`landing-retiro.png`, columna derecha de "Pedís hoy") pasa a ir a sangre (de punta a punta de la pantalla), igual que las de "Idea" y "¿Por qué BROT 74?" — reemplaza el tratamiento "contenida al 72%, centrada" que traía la entrega v34.

## Por qué
Pedido explícito. Desktop no se toca.

## Cómo
- Se agregó `media-bleed` (la misma utility class que ya usan las otras 3 fotos) al contenedor de esta imagen.
- La utility `.media-bleed` no tenía `max-width` en su lista de `!important` — ningún otro `.media` lo necesitaba. `.retiro-media` sí trae `max-width: 100%` (para acotarla en desktop a 481px), y sin overridearlo el ancho quedaba capado al de su columna (335px) en vez de los 100vw pedidos. Se agrega `max-width: 100vw !important` a la utility, general para cualquier uso futuro.
- `sizes` de `next/image` para esta foto: `72vw` → `100vw`, para que pida una versión suficientemente grande al nuevo ancho completo en mobile.

## Testing
- Verificado en localhost a 375px: `left: 0, width: 375` (ancho completo), sin scroll horizontal.
- Verificado en desktop (1280px): sin cambios — `width: 481px`, `max-width: 100%`, mismo `translateY`.
- `npm run test:e2e` — 2/2 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)