### PR TITLE
feat(BRT-142): Nivel 1 — aprobación automática de PRs no críticas

### DIFF
--- a/scripts/dependabot-triage/actions.ts
+++ b/scripts/dependabot-triage/actions.ts
@@ -1,0 +1,125 @@
+import { ghApi, repoSlug, runGh, type DependabotPrRisk } from "./github.js";
+import type { RiskResult } from "./risk.js";
+
+/**
+ * BRT-142: Nivel 1 del agente — aprueba automáticamente las PRs no
+ * críticas cuando sus checks obligatorios (`lint` e `integration` de
+ * test.yml) están en verde. Nunca mergea: eso queda para Nivel 2
+ * (BRT-146, a futuro) y sigue siendo 100% manual acá.
+ */
+
+// Los checks que test.yml expone como jobs — deben coincidir con los
+// `name:` de los jobs en .github/workflows/test.yml.
+const REQUIRED_CHECKS = ["lint", "integration"];
+
+export type EstadoChecks = "verde" | "rojo" | "pendiente";
+
+export type Accion = "aprobada" | "no-tocada";
+
+export interface AccionResultado {
+  accion: Accion;
+  motivoAccion: string;
+}
+
+interface PullRequestDetail {
+  head: { sha: string };
+}
+
+interface CheckRun {
+  name: string;
+  status: "queued" | "in_progress" | "completed";
+  conclusion: string | null;
+  started_at: string;
+}
+
+/**
+ * Toma, para cada check requerido, la corrida más reciente (por si hubo
+ * un re-run) y evalúa el estado combinado:
+ *
+ * - "rojo" si algún check requerido terminó y no fue exitoso.
+ * - "pendiente" si algún check requerido todavía no terminó o ni corrió.
+ * - "verde" solo si los dos requeridos terminaron con éxito.
+ */
+export function estadoDeChecksRequeridos(checkRuns: CheckRun[]): EstadoChecks {
+  const masReciente = (nombre: string): CheckRun | undefined =>
+    checkRuns
+      .filter((run) => run.name === nombre)
+      .sort((a, b) => b.started_at.localeCompare(a.started_at))[0];
+
+  const estados = REQUIRED_CHECKS.map((nombre) => masReciente(nombre));
+
+  if (estados.some((run) => !run || run.status !== "completed")) {
+    return "pendiente";
+  }
+  if (estados.some((run) => run?.conclusion !== "success")) {
+    return "rojo";
+  }
+  return "verde";
+}
+
+function getEstadoChecksParaPR(owner: string, repo: string, numero: number): EstadoChecks {
+  const pr = ghApi<PullRequestDetail>(`repos/${owner}/${repo}/pulls/${numero}`);
+  const { check_runs: checkRuns } = ghApi<{ check_runs: CheckRun[] }>(
+    `repos/${owner}/${repo}/commits/${pr.head.sha}/check-runs?per_page=100`,
+  );
+  return estadoDeChecksRequeridos(checkRuns);
+}
+
+function aprobarPR(owner: string, repo: string, numero: number, motivoClasificacion: string): void {
+  runGh([
+    "pr",
+    "review",
+    String(numero),
+    "--repo",
+    `${owner}/${repo}`,
+    "--approve",
+    "--body",
+    `🤖 Aprobada automáticamente por el agente de triage de Dependabot (Nivel 1) — ${motivoClasificacion} CI en verde (lint + integration). El merge sigue siendo manual.`,
+  ]);
+}
+
+/**
+ * Aplica el Nivel 1 a cada PR ya clasificada (BRT-140): aprueba las no
+ * críticas con CI en verde, y deja constancia del motivo cuando no toca
+ * una PR (crítica, CI en rojo, o checks todavía corriendo).
+ */
+export function aplicarNivel1<T extends DependabotPrRisk & RiskResult>(
+  clasificadas: T[],
+): (T & AccionResultado)[] {
+  const [owner, repo] = repoSlug().split("/");
+
+  return clasificadas.map((pr) => {
+    if (pr.critica) {
+      return {
+        ...pr,
+        accion: "no-tocada",
+        motivoAccion: "PR crítica — requiere revisión humana, el agente no actúa.",
+      };
+    }
+
+    const estado = getEstadoChecksParaPR(owner, repo, pr.numero);
+
+    if (estado === "pendiente") {
+      return {
+        ...pr,
+        accion: "no-tocada",
+        motivoAccion: "No crítica, pero lint/integration todavía no terminaron — se evalúa de nuevo mañana.",
+      };
+    }
+
+    if (estado === "rojo") {
+      return {
+        ...pr,
+        accion: "no-tocada",
+        motivoAccion: "No crítica, pero CI está en rojo (lint o integration fallaron) — no se aprueba sola.",
+      };
+    }
+
+    aprobarPR(owner, repo, pr.numero, pr.motivo);
+    return {
+      ...pr,
+      accion: "aprobada",
+      motivoAccion: "No crítica y CI en verde — aprobada automáticamente. Falta el merge manual.",
+    };
+  });
+}

--- a/scripts/dependabot-triage/github.ts
+++ b/scripts/dependabot-triage/github.ts
@@ -96,14 +96,23 @@ export function repoSlug(): string {
   return match[1];
 }
 
-function ghApi<T>(path: string, token?: string): T {
-  const output = execFileSync(resolveExecutable("gh"), ["api", path], {
+/**
+ * Corre un comando `gh` arbitrario (no solo `gh api`) resolviendo el
+ * ejecutable por path absoluto. Exportada para que el resto del agente
+ * (BRT-142: aprobar PRs) reuse el mismo mecanismo en vez de invocar `gh`
+ * por su cuenta.
+ */
+export function runGh(args: string[], token?: string): string {
+  return execFileSync(resolveExecutable("gh"), args, {
     encoding: "utf8",
     // Sin `token`, hereda el auth de `gh` tal cual (GITHUB_TOKEN del
     // workflow, o la sesión de `gh auth login` local).
     env: token ? { ...process.env, GH_TOKEN: token } : process.env,
   });
-  return JSON.parse(output) as T;
+}
+
+export function ghApi<T>(path: string, token?: string): T {
+  return JSON.parse(runGh(["api", path], token)) as T;
 }
 
 function listOpenDependabotPRs(owner: string, repo: string): GitHubPullRequest[] {

--- a/scripts/dependabot-triage/index.ts
+++ b/scripts/dependabot-triage/index.ts
@@ -1,55 +1,68 @@
 import { appendFileSync } from "node:fs";
-import { classifyDependabotPRs } from "./risk.js";
+import { aplicarNivel1 } from "./actions.js";
 import type { DependabotPrRisk } from "./github.js";
+import { classifyDependabotPRs } from "./risk.js";
 
 /**
  * BRT-141: entrypoint que corre el workflow de GitHub Actions
  * (.github/workflows/dependabot-triage.yml).
  *
- * Hoy solo detecta (BRT-139) + clasifica (BRT-140) y deja un resumen en el
- * job summary de Actions — todavía NO actúa sobre las PRs (Nivel 1:
- * BRT-142) ni gestiona tickets de Jira o Slack (BRT-143/BRT-144). Ese
- * trabajo se suma acá mismo a medida que esas historias se implementen.
+ * Detecta (BRT-139) + clasifica (BRT-140) + aplica Nivel 1 (BRT-142: aprueba
+ * las no críticas con CI en verde, nunca mergea) y deja un resumen en el job
+ * summary de Actions. Todavía NO gestiona tickets de Jira ni Slack
+ * (BRT-143/BRT-144) — se suma acá mismo cuando esas historias se implementen.
  */
 
-type PrClasificada = DependabotPrRisk & { critica: boolean; motivo: string };
+type PrProcesada = DependabotPrRisk & {
+  critica: boolean;
+  motivo: string;
+  accion: "aprobada" | "no-tocada";
+  motivoAccion: string;
+};
 
-function resumenMarkdown(clasificadas: PrClasificada[]): string {
-  if (clasificadas.length === 0) {
+const ICONO_ACCION: Record<PrProcesada["accion"], string> = {
+  aprobada: "✅ aprobada",
+  "no-tocada": "⏸️ sin tocar",
+};
+
+function resumenMarkdown(procesadas: PrProcesada[]): string {
+  if (procesadas.length === 0) {
     return "## 🤖 Triage de Dependabot\n\nNo hay PRs abiertas de Dependabot hoy.\n";
   }
 
-  const criticas = clasificadas.filter((pr) => pr.critica).length;
+  const criticas = procesadas.filter((pr) => pr.critica).length;
+  const aprobadas = procesadas.filter((pr) => pr.accion === "aprobada").length;
 
-  const filas = clasificadas
+  const filas = procesadas
     .map((pr) => {
       const estado = pr.critica ? "🔴 crítica" : "🟢 no crítica";
-      return `| [#${pr.numero}](${pr.url}) | \`${pr.paquete}\` | ${pr.bumpType} | ${pr.severidad ?? "-"} | ${estado} | ${pr.motivo} |`;
+      return `| [#${pr.numero}](${pr.url}) | \`${pr.paquete}\` | ${pr.bumpType} | ${pr.severidad ?? "-"} | ${estado} | ${ICONO_ACCION[pr.accion]} | ${pr.motivoAccion} |`;
     })
     .join("\n");
 
   return [
     "## 🤖 Triage de Dependabot",
     "",
-    `${clasificadas.length} PR(s) abierta(s) — ${criticas} crítica(s).`,
+    `${procesadas.length} PR(s) abierta(s) — ${criticas} crítica(s), ${aprobadas} aprobada(s) automáticamente.`,
     "",
-    "| PR | Paquete | Bump | Severidad | Estado | Motivo |",
-    "|---|---|---|---|---|---|",
+    "| PR | Paquete | Bump | Severidad | Estado | Nivel 1 | Motivo |",
+    "|---|---|---|---|---|---|---|",
     filas,
     "",
-    "_Nivel 1 (aprobación automática) y la gestión de tickets/Slack todavía no están" +
-      " implementados — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
+    "_El merge sigue siendo manual en todos los casos. Gestión de tickets/Slack todavía" +
+      " no está implementada — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
   ].join("\n");
 }
 
 function main(): void {
   const clasificadas = classifyDependabotPRs();
+  const procesadas = aplicarNivel1(clasificadas);
 
-  console.log(JSON.stringify(clasificadas, null, 2));
+  console.log(JSON.stringify(procesadas, null, 2));
 
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {
-    appendFileSync(summaryPath, resumenMarkdown(clasificadas));
+    appendFileSync(summaryPath, resumenMarkdown(procesadas));
   }
 }
 


### PR DESCRIPTION
## Qué

Agrega [scripts/dependabot-triage/actions.ts](scripts/dependabot-triage/actions.ts) — Nivel 1 del agente ([BRT-137](https://brot74.atlassian.net/browse/BRT-137)):

- **PR crítica** → nunca la toca, ni siquiera consulta sus checks.
- **PR no crítica con `lint`/`integration` (test.yml) en verde** → la aprueba con `gh pr review --approve` + comentario con el motivo. **Nunca mergea** (eso es Nivel 2, [BRT-146](https://brot74.atlassian.net/browse/BRT-146), backlog a futuro).
- **PR no crítica con CI en rojo o corriendo todavía** → no la toca, queda reportada para la próxima corrida.

`estadoDeChecksRequeridos()` toma, por cada check requerido, la corrida más reciente (soporta re-runs) y evalúa verde/rojo/pendiente.

`github.ts` ahora exporta `runGh()`/`ghApi()` (antes privadas) para que `actions.ts` reuse la resolución de ejecutable por path absoluto (BRT-139/Sonar S4036) en vez de invocar `gh` por su cuenta. `index.ts` integra Nivel 1 al pipeline completo y lo refleja en el job summary.

## Verificación — sin tocar el repo real

Corriendo esto en vivo ahora mismo aprobaría de verdad 5 PRs abiertas (repo público). Antes de eso, confirmé con el usuario si quería la evidencia en vivo o solo verificación de lógica — eligió **verificar sin aprobar nada todavía**. Entonces:

- **12 PRs reales de hoy**: las 7 críticas no consultan checks (regla respetada). Las 5 no críticas (`baseline-browser-mapping` #116, `lucide-react` #91, `@types/node` #87, `eslint-config-next` #85, `tsx` #84) tienen `lint`+`integration` en verde — confirmado leyendo sus checks reales, sin llamar a `aprobarPR`.
- **5 casos sintéticos** de `estadoDeChecksRequeridos()`: verde (ambos success), rojo (uno falló), pendiente (uno corriendo), pendiente (uno ni arrancó), y verde en un re-run (falló y después pasó — toma la corrida más reciente).

`npx tsc --noEmit` limpio, `npm run lint` sin errores (mismos warnings `security/detect-*` de siempre, ninguno nuevo en `actions.ts`).

**Importante:** la primera aprobación real va a pasar en la próxima corrida del workflow (cron de mañana 09:00 ART, o un `workflow_dispatch` manual) una vez mergeado esto — con los datos de hoy, aprobaría esas mismas 5 PRs.

## Nota aparte

Al pushear, GitHub reportó 7 vulnerabilidades en `main` (2 critical, 3 high, 1 moderate, 1 low) — subió de las 2 que había al arrancar la épica. Coincide con lo que ya veíamos en `risk.ts` (js-yaml, browserslist, next, sharp con severidad real). No es parte de este PR, lo dejo anotado.

## Fuera de alcance

Jira, Slack, Nivel 2 — historias separadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-137]: https://brot74.atlassian.net/browse/BRT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-146]: https://brot74.atlassian.net/browse/BRT-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Level 1 Dependabot triage automation.
  - Automatically approves non-critical pull requests when required CI checks pass.
  - Leaves a clear reason for critical pull requests or those with failing or pending checks.
  - Triage summaries now show each pull request’s action status, include approval counts, and add a Level 1 status column.
  - Pull request merging remains a manual step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->