### PR TITLE
feat(BRT-143): gestión de tickets Jira del agente de triage

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -4,10 +4,10 @@ name: Dependabot Triage Agent
 # test.yml a propósito: no es CI de la app, es un proceso de mantenimiento
 # del repo. Corre en cron todos los días y se puede disparar a mano.
 #
-# Hoy solo detecta + clasifica (BRT-139/BRT-140) y deja un resumen — todavía
-# no aprueba PRs (Nivel 1: BRT-142) ni toca Jira/Slack (BRT-143/BRT-144).
-# Cuando esas historias se implementen, este workflow no necesita cambios:
-# solo va a hacer más el mismo `npm run dependabot:triage`.
+# Detecta + clasifica (BRT-139/BRT-140), aprueba las no críticas con CI
+# verde (Nivel 1: BRT-142) y gestiona tickets de Jira (BRT-143). Todavía no
+# notifica a Slack (BRT-144) — cuando se implemente, este workflow no
+# necesita cambios: solo va a hacer más el mismo `npm run dependabot:triage`.
 
 on:
   schedule:
@@ -44,11 +44,17 @@ jobs:
       # justamente existe para manejar riesgo de dependencias.
       - run: npm ci --ignore-scripts
 
-      - name: Detectar y clasificar PRs de Dependabot
+      - name: Detectar, clasificar, aprobar y actualizar Jira
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # BRT-147: PAT propio con permiso de lectura de Dependabot Alerts
           # (el GITHUB_TOKEN default no puede leer ese endpoint). Optativo:
           # si el secret no existe, el paso sigue andando sin severidad.
           DEPENDABOT_ALERTS_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
+          # BRT-143: credenciales de Jira (API token propio, no OAuth) para
+          # crear/buscar tickets. Optativo: sin estos secrets, el paso sigue
+          # corriendo (detección + clasificación + Nivel 1) sin tocar Jira.
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         run: npm run dependabot:triage

--- a/scripts/dependabot-triage/index.ts
+++ b/scripts/dependabot-triage/index.ts
@@ -1,6 +1,7 @@
 import { appendFileSync } from "node:fs";
 import { aplicarNivel1 } from "./actions.js";
 import type { DependabotPrRisk } from "./github.js";
+import { actualizarJira, type ResultadoJira } from "./jira.js";
 import { classifyDependabotPRs } from "./risk.js";
 
 /**
@@ -8,9 +9,9 @@ import { classifyDependabotPRs } from "./risk.js";
  * (.github/workflows/dependabot-triage.yml).
  *
  * Detecta (BRT-139) + clasifica (BRT-140) + aplica Nivel 1 (BRT-142: aprueba
- * las no críticas con CI en verde, nunca mergea) y deja un resumen en el job
- * summary de Actions. Todavía NO gestiona tickets de Jira ni Slack
- * (BRT-143/BRT-144) — se suma acá mismo cuando esas historias se implementen.
+ * las no críticas con CI en verde, nunca mergea) + gestiona tickets de Jira
+ * (BRT-143) y deja un resumen en el job summary de Actions. Todavía NO
+ * notifica a Slack (BRT-144) — se suma acá mismo cuando se implemente.
  */
 
 type PrProcesada = DependabotPrRisk & {
@@ -25,7 +26,7 @@ const ICONO_ACCION: Record<PrProcesada["accion"], string> = {
   "no-tocada": "⏸️ sin tocar",
 };
 
-function resumenMarkdown(procesadas: PrProcesada[]): string {
+function resumenMarkdown(procesadas: PrProcesada[], jira: ResultadoJira): string {
   if (procesadas.length === 0) {
     return "## 🤖 Triage de Dependabot\n\nNo hay PRs abiertas de Dependabot hoy.\n";
   }
@@ -40,6 +41,14 @@ function resumenMarkdown(procesadas: PrProcesada[]): string {
     })
     .join("\n");
 
+  const lineaJira = jira.omitido
+    ? `_Jira: no se gestionaron tickets esta corrida (${jira.omitido})._`
+    : `_Jira: ticket batch [${jira.batchKey}](${jiraIssueUrl(jira.batchKey)})` +
+      (jira.criticasNuevas.length > 0
+        ? `, tickets nuevos por crítica: ${jira.criticasNuevas.map((k) => `[${k}](${jiraIssueUrl(k)})`).join(", ")}.`
+        : ".") +
+      "_";
+
   return [
     "## 🤖 Triage de Dependabot",
     "",
@@ -49,20 +58,31 @@ function resumenMarkdown(procesadas: PrProcesada[]): string {
     "|---|---|---|---|---|---|---|",
     filas,
     "",
-    "_El merge sigue siendo manual en todos los casos. Gestión de tickets/Slack todavía" +
-      " no está implementada — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
+    "_El merge sigue siendo manual en todos los casos. Notificación a Slack todavía no" +
+      " está implementada — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
+    "",
+    lineaJira,
   ].join("\n");
 }
 
-function main(): void {
+function jiraIssueUrl(key: string | null): string {
+  if (!key) return "#";
+  const baseUrl = (process.env.JIRA_BASE_URL ?? "").replace(/\/$/, "");
+  return `${baseUrl}/browse/${key}`;
+}
+
+async function main(): Promise<void> {
   const clasificadas = classifyDependabotPRs();
   const procesadas = aplicarNivel1(clasificadas);
 
   console.log(JSON.stringify(procesadas, null, 2));
 
+  const jira = await actualizarJira(procesadas);
+  console.log("Jira:", jira);
+
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {
-    appendFileSync(summaryPath, resumenMarkdown(procesadas));
+    appendFileSync(summaryPath, resumenMarkdown(procesadas, jira));
   }
 }
 

--- a/scripts/dependabot-triage/jira.ts
+++ b/scripts/dependabot-triage/jira.ts
@@ -1,0 +1,253 @@
+import type { DependabotPrRisk } from "./github.js";
+import type { AccionResultado } from "./actions.js";
+import type { RiskResult } from "./risk.js";
+
+/**
+ * BRT-143: gestión de tickets Jira del agente de triage.
+ *
+ * - Un ticket "batch" por día (Task, label `dependabot-batch-YYYY-MM-DD`)
+ *   agrupa el resumen de la corrida. Se autocierra si no quedó ninguna PR
+ *   crítica sin resolver.
+ * - Un ticket dedicado por PR crítica (Bug, label `dependabot-pr-<numero>`)
+ *   con el análisis de riesgo. No se autocierra — requiere revisión humana.
+ *
+ * Habla directo con la Jira REST API v3 (no el MCP de Atlassian: este
+ * script corre en un runner de GitHub Actions, no dentro de una sesión de
+ * Claude). Necesita `JIRA_BASE_URL`, `JIRA_EMAIL`, `JIRA_API_TOKEN` como
+ * env vars — si faltan, no gestiona tickets pero no rompe el resto de la
+ * corrida (mismo criterio que BRT-139 con Dependabot Alerts).
+ *
+ * Nota sobre el endpoint de búsqueda: `/rest/api/3/search` (clásico) está
+ * dado de baja por Atlassian (410 Gone desde fines de octubre de 2025) —
+ * acá se usa su reemplazo, `POST /rest/api/3/search/jql`, con paginación
+ * por `nextPageToken` en vez de `startAt`.
+ */
+
+const PROJECT_KEY = process.env.JIRA_PROJECT_KEY ?? "BRT";
+
+export type PrProcesada = DependabotPrRisk & RiskResult & AccionResultado;
+
+export interface ResultadoJira {
+  batchKey: string | null;
+  criticasNuevas: string[];
+  omitido?: string;
+}
+
+function credencialesFaltantes(): string | null {
+  const requeridas = ["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"];
+  const faltan = requeridas.filter((nombre) => !process.env[nombre]);
+  if (faltan.length === 0) return null;
+  return `Faltan env vars de Jira: ${faltan.join(", ")}`;
+}
+
+function authHeader(): string {
+  const email = process.env.JIRA_EMAIL ?? "";
+  const token = process.env.JIRA_API_TOKEN ?? "";
+  return `Basic ${Buffer.from(`${email}:${token}`).toString("base64")}`;
+}
+
+async function jiraFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const baseUrl = (process.env.JIRA_BASE_URL ?? "").replace(/\/$/, "");
+  const res = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      Authorization: authHeader(),
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...init?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const cuerpo = await res.text().catch(() => "");
+    throw new Error(`Jira ${init?.method ?? "GET"} ${path} -> HTTP ${res.status}: ${cuerpo.slice(0, 500)}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+/** Convierte texto plano (párrafos separados por línea en blanco) a ADF. */
+function textoAAdf(texto: string) {
+  const parrafos = texto
+    .split(/\n{2,}/)
+    .map((bloque) => bloque.trim())
+    .filter(Boolean);
+
+  return {
+    type: "doc",
+    version: 1,
+    content: parrafos.map((bloque) => ({
+      type: "paragraph",
+      content: bloque.split("\n").flatMap((linea, i, arr) => {
+        const nodos: Record<string, unknown>[] = [{ type: "text", text: linea || " " }];
+        if (i < arr.length - 1) nodos.push({ type: "hardBreak" });
+        return nodos;
+      }),
+    })),
+  };
+}
+
+interface JiraIssueSummary {
+  key: string;
+}
+
+async function buscarPorJql(jql: string): Promise<JiraIssueSummary[]> {
+  const resultado = await jiraFetch<{ issues: JiraIssueSummary[] }>("/rest/api/3/search/jql", {
+    method: "POST",
+    body: JSON.stringify({ jql, maxResults: 5, fields: ["summary"] }),
+  });
+  return resultado.issues;
+}
+
+async function crearIssue(campos: Record<string, unknown>): Promise<string> {
+  const creado = await jiraFetch<{ key: string }>("/rest/api/3/issue", {
+    method: "POST",
+    body: JSON.stringify({ fields: campos }),
+  });
+  return creado.key;
+}
+
+async function linkearIssues(inwardKey: string, outwardKey: string): Promise<void> {
+  await jiraFetch("/rest/api/3/issueLink", {
+    method: "POST",
+    body: JSON.stringify({
+      type: { name: "Relates" },
+      inwardIssue: { key: inwardKey },
+      outwardIssue: { key: outwardKey },
+    }),
+  });
+}
+
+async function cerrarComoDone(issueKey: string): Promise<void> {
+  const { transitions } = await jiraFetch<{
+    transitions: { id: string; to: { statusCategory: { key: string } } }[];
+  }>(`/rest/api/3/issue/${issueKey}/transitions`);
+
+  const done = transitions.find((t) => t.to.statusCategory.key === "done");
+  if (!done) {
+    console.warn(`No encontré una transición a "Done" para ${issueKey} — lo dejo como está.`);
+    return;
+  }
+  await jiraFetch(`/rest/api/3/issue/${issueKey}/transitions`, {
+    method: "POST",
+    body: JSON.stringify({ transition: { id: done.id } }),
+  });
+}
+
+function urlDeLaCorrida(): string | undefined {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return undefined;
+  return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+}
+
+function resumenBatchTexto(fecha: string, procesadas: PrProcesada[]): string {
+  const criticas = procesadas.filter((pr) => pr.critica);
+  const lineas = procesadas.map(
+    (pr) =>
+      `#${pr.numero} ${pr.paquete} (${pr.bumpType}${pr.severidad ? `, severidad ${pr.severidad}` : ""}) — ` +
+      `${pr.critica ? "CRÍTICA" : "no crítica"} — ${pr.accion} — ${pr.motivoAccion} — ${pr.url}`,
+  );
+
+  const partes = [
+    `Triage automático de PRs de Dependabot del ${fecha}.`,
+    `${procesadas.length} PR(s) procesadas, ${criticas.length} crítica(s).`,
+    lineas.join("\n"),
+  ];
+
+  const run = urlDeLaCorrida();
+  if (run) partes.push(`Corrida completa: ${run}`);
+
+  return partes.join("\n\n");
+}
+
+function resumenCriticaTexto(pr: PrProcesada): string {
+  const partes = [
+    `PR de Dependabot clasificada como crítica por el agente de triage (BRT-137).`,
+    `Paquete: ${pr.paquete}\nBump: ${pr.bumpType}${pr.versionDesde && pr.versionHasta ? ` (${pr.versionDesde} → ${pr.versionHasta})` : ""}\nSeveridad: ${pr.severidad ?? "sin CVE asociado"}`,
+    `Motivo: ${pr.motivo}`,
+    `PR: ${pr.url}`,
+  ];
+  return partes.join("\n\n");
+}
+
+/**
+ * Busca (o crea) el ticket batch del día. Idempotente: reintentar la misma
+ * corrida el mismo día devuelve el ticket ya existente en vez de duplicar.
+ */
+async function findOrCreateBatchIssue(fecha: string, procesadas: PrProcesada[]): Promise<string> {
+  const label = `dependabot-batch-${fecha}`;
+  const existentes = await buscarPorJql(
+    `project = "${PROJECT_KEY}" AND labels = "${label}" ORDER BY created DESC`,
+  );
+  if (existentes.length > 0) return existentes[0].key;
+
+  return crearIssue({
+    project: { key: PROJECT_KEY },
+    issuetype: { name: "Task" },
+    summary: `Triage de Dependabot — ${fecha}`,
+    description: textoAAdf(resumenBatchTexto(fecha, procesadas)),
+    labels: ["dependabot-batch", label],
+  });
+}
+
+/**
+ * Busca (o crea) el ticket dedicado de una PR crítica. Idempotente dentro
+ * del mismo día: si ya existe uno abierto para esa PR, no crea otro.
+ */
+async function findOrCreateCriticalIssue(
+  pr: PrProcesada,
+): Promise<{ key: string; esNuevo: boolean }> {
+  const label = `dependabot-pr-${pr.numero}`;
+  const existentes = await buscarPorJql(
+    `project = "${PROJECT_KEY}" AND labels = "${label}" AND statusCategory != Done ORDER BY created DESC`,
+  );
+  if (existentes.length > 0) return { key: existentes[0].key, esNuevo: false };
+
+  const key = await crearIssue({
+    project: { key: PROJECT_KEY },
+    issuetype: { name: "Bug" },
+    summary: `[Dependabot] PR crítica: ${pr.paquete} (#${pr.numero})`,
+    description: textoAAdf(resumenCriticaTexto(pr)),
+    labels: ["dependabot-critica", label],
+  });
+  return { key, esNuevo: true };
+}
+
+/**
+ * Punto de entrada: actualiza Jira con el resultado de la corrida. No es
+ * fatal si falla (credenciales ausentes, Jira caído) — loguea y sigue, no
+ * tira abajo el resto del pipeline (las aprobaciones de Nivel 1 ya
+ * corrieron antes de llegar acá).
+ */
+export async function actualizarJira(procesadas: PrProcesada[]): Promise<ResultadoJira> {
+  const faltantes = credencialesFaltantes();
+  if (faltantes) {
+    console.warn(`${faltantes} — no se gestionan tickets de Jira esta corrida.`);
+    return { batchKey: null, criticasNuevas: [], omitido: faltantes };
+  }
+
+  try {
+    const fecha = new Date().toISOString().slice(0, 10);
+    const batchKey = await findOrCreateBatchIssue(fecha, procesadas);
+
+    const criticas = procesadas.filter((pr) => pr.critica);
+    const criticasNuevas: string[] = [];
+
+    for (const pr of criticas) {
+      const { key, esNuevo } = await findOrCreateCriticalIssue(pr);
+      if (esNuevo) {
+        await linkearIssues(batchKey, key);
+        criticasNuevas.push(key);
+      }
+    }
+
+    if (criticas.length === 0) {
+      await cerrarComoDone(batchKey);
+    }
+
+    return { batchKey, criticasNuevas };
+  } catch (err) {
+    console.warn("Falló la gestión de tickets de Jira (se sigue sin romper la corrida):", (err as Error).message);
+    return { batchKey: null, criticasNuevas: [], omitido: (err as Error).message };
+  }
+}


### PR DESCRIPTION
## Qué

Agrega [scripts/dependabot-triage/jira.ts](scripts/dependabot-triage/jira.ts) — trazabilidad en Jira de cada corrida del agente ([BRT-137](https://brot74.atlassian.net/browse/BRT-137)):

- **Ticket batch diario** (Task, label `dependabot-batch-YYYY-MM-DD`): agrupa el resumen de la corrida. Busca por JQL antes de crear (idempotente en reintentos el mismo día). Se autocierra a Done si no quedó ninguna PR crítica sin resolver.
- **Ticket dedicado por PR crítica** (Bug, label `dependabot-pr-<numero>`): paquete, bump, severidad, motivo, link a la PR. Se linkea ("Relates") al batch del día. No duplica si ya existe uno abierto para la misma PR.

Habla directo con la **Jira REST API v3** (no el MCP de Atlassian — este script corre en un runner de Actions, no en una sesión de Claude). Sin `JIRA_BASE_URL`/`JIRA_EMAIL`/`JIRA_API_TOKEN`, o si Jira falla, no gestiona tickets pero no rompe el resto de la corrida (las aprobaciones de Nivel 1 ya corrieron antes).

## Nota de implementación importante

`/rest/api/3/search` (el endpoint clásico de búsqueda) está **dado de baja por Atlassian** (410 Gone desde fines de octubre 2025). Lo detecté investigando antes de escribir código — se usa el reemplazo, `POST /rest/api/3/search/jql`, con paginación por `nextPageToken` en vez de `startAt`.

`index.ts` integra Jira al pipeline completo y lo refleja en el job summary. El workflow pasa los 3 secrets (optativos) al paso de triage.

## Verificación

No tengo credenciales válidas de Jira (las crea el usuario — ver abajo). Lo que sí verifiqué:

- **Sin las 3 env vars seteadas**: se salta Jira con un warning claro (`Faltan env vars de Jira: ...`), no rompe.
- **Con credenciales inválidas contra la Jira real** (`brot74.atlassian.net`): confirma que el ciclo HTTP completo funciona de punta a punta (fetch, headers, parseo de error JSON) y que un fallo real tampoco rompe la corrida — solo loguea y sigue.

Deliberadamente **no** corrí esto con `aplicarNivel1` real (ya aprueba PRs de verdad desde BRT-142) — probé `actualizarJira()` aislado con datos sintéticos para no disparar aprobaciones de más.

`npx tsc --noEmit` limpio, `npm run lint` sin errores (mismos warnings `security/detect-*` de siempre).

## Lo que falta (acción manual del usuario, mismo patrón que BRT-147)

1. Crear un API token de Jira en [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens).
2. Setear los 3 secrets desde la terminal (no pegándomelos a mí):
   ```
   gh secret set JIRA_BASE_URL --repo gastton/brot74-web --body "https://brot74.atlassian.net"
   gh secret set JIRA_EMAIL --repo gastton/brot74-web --body "tu-email@..."
   gh secret set JIRA_API_TOKEN --repo gastton/brot74-web
   ```
3. Validamos con un `workflow_dispatch` real antes de dejarlo en manos del cron.

## Fuera de alcance

Slack ([BRT-144](https://brot74.atlassian.net/browse/BRT-144)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-137]: https://brot74.atlassian.net/browse/BRT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRT-144]: https://brot74.atlassian.net/browse/BRT-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ