### PR TITLE
fix(BRT-149): PAT dedicado para aprobar PRs + resiliencia por PR

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -51,6 +51,12 @@ jobs:
           # (el GITHUB_TOKEN default no puede leer ese endpoint). Optativo:
           # si el secret no existe, el paso sigue andando sin severidad.
           DEPENDABOT_ALERTS_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
+          # BRT-149: GitHub bloquea a nivel de plataforma que el GITHUB_TOKEN
+          # default apruebe PRs ("GitHub Actions is not permitted to approve
+          # pull requests") — hace falta un PAT de una identidad real.
+          # Optativo: sin este secret, el agente detecta/clasifica/reporta
+          # pero no aprueba nada.
+          PR_APPROVE_TOKEN: ${{ secrets.PR_APPROVE_TOKEN }}
           # BRT-143: credenciales de Jira (API token propio, no OAuth) para
           # crear/buscar tickets. Optativo: sin estos secrets, el paso sigue
           # corriendo (detección + clasificación + Nivel 1) sin tocar Jira.

--- a/scripts/dependabot-triage/actions.ts
+++ b/scripts/dependabot-triage/actions.ts
@@ -65,17 +65,62 @@ function getEstadoChecksParaPR(owner: string, repo: string, numero: number): Est
   return estadoDeChecksRequeridos(checkRuns);
 }
 
-function aprobarPR(owner: string, repo: string, numero: number, motivoClasificacion: string): void {
-  runGh([
-    "pr",
-    "review",
-    String(numero),
-    "--repo",
-    `${owner}/${repo}`,
-    "--approve",
-    "--body",
-    `🤖 Aprobada automáticamente por el agente de triage de Dependabot (Nivel 1) — ${motivoClasificacion} CI en verde (lint + integration). El merge sigue siendo manual.`,
-  ]);
+/**
+ * BRT-149: GitHub bloquea a nivel de plataforma que el `GITHUB_TOKEN`
+ * default de un workflow apruebe PRs ("GitHub Actions is not permitted to
+ * approve pull requests") — no es un tema de permisos del workflow, es una
+ * restricción fija para evitar que un workflow se auto-apruebe sus propios
+ * cambios. Hace falta un PAT de una identidad real, igual que ya resolvimos
+ * para Dependabot Alerts (BRT-147) y Jira (BRT-143).
+ */
+function tokenDeAprobacion(): string | undefined {
+  return process.env.PR_APPROVE_TOKEN;
+}
+
+/**
+ * Intenta aprobar la PR. Nunca tira una excepción hacia arriba — un fallo
+ * puntual (auth, rate limit, lo que sea) no debe frenar el resto de la
+ * corrida ni la actualización de Jira (BRT-149: antes crasheaba todo el
+ * proceso acá mismo).
+ */
+function intentarAprobar(
+  owner: string,
+  repo: string,
+  numero: number,
+  motivoClasificacion: string,
+): { aprobada: boolean; motivo: string } {
+  const token = tokenDeAprobacion();
+  if (!token) {
+    return {
+      aprobada: false,
+      motivo: "No crítica y CI en verde, pero falta PR_APPROVE_TOKEN — el agente no puede aprobar sin un PAT propio.",
+    };
+  }
+
+  try {
+    runGh(
+      [
+        "pr",
+        "review",
+        String(numero),
+        "--repo",
+        `${owner}/${repo}`,
+        "--approve",
+        "--body",
+        `🤖 Aprobada automáticamente por el agente de triage de Dependabot (Nivel 1) — ${motivoClasificacion} CI en verde (lint + integration). El merge sigue siendo manual.`,
+      ],
+      token,
+    );
+    return {
+      aprobada: true,
+      motivo: "No crítica y CI en verde — aprobada automáticamente. Falta el merge manual.",
+    };
+  } catch (err) {
+    return {
+      aprobada: false,
+      motivo: `No crítica y CI en verde, pero falló la aprobación (se reintenta en la próxima corrida): ${(err as Error).message}`,
+    };
+  }
 }
 
 /**
@@ -97,29 +142,40 @@ export function aplicarNivel1<T extends DependabotPrRisk & RiskResult>(
       };
     }
 
-    const estado = getEstadoChecksParaPR(owner, repo, pr.numero);
+    // BRT-149: cualquier fallo puntual acá (consultar checks, aprobar) no
+    // debe frenar el resto de las PRs ni la actualización de Jira — se
+    // reporta esta PR como no tocada y la corrida sigue.
+    try {
+      const estado = getEstadoChecksParaPR(owner, repo, pr.numero);
 
-    if (estado === "pendiente") {
+      if (estado === "pendiente") {
+        return {
+          ...pr,
+          accion: "no-tocada",
+          motivoAccion: "No crítica, pero lint/integration todavía no terminaron — se evalúa de nuevo mañana.",
+        };
+      }
+
+      if (estado === "rojo") {
+        return {
+          ...pr,
+          accion: "no-tocada",
+          motivoAccion: "No crítica, pero CI está en rojo (lint o integration fallaron) — no se aprueba sola.",
+        };
+      }
+
+      const resultado = intentarAprobar(owner, repo, pr.numero, pr.motivo);
+      return {
+        ...pr,
+        accion: resultado.aprobada ? "aprobada" : "no-tocada",
+        motivoAccion: resultado.motivo,
+      };
+    } catch (err) {
       return {
         ...pr,
         accion: "no-tocada",
-        motivoAccion: "No crítica, pero lint/integration todavía no terminaron — se evalúa de nuevo mañana.",
+        motivoAccion: `No se pudo procesar esta PR (se reintenta en la próxima corrida): ${(err as Error).message}`,
       };
     }
-
-    if (estado === "rojo") {
-      return {
-        ...pr,
-        accion: "no-tocada",
-        motivoAccion: "No crítica, pero CI está en rojo (lint o integration fallaron) — no se aprueba sola.",
-      };
-    }
-
-    aprobarPR(owner, repo, pr.numero, pr.motivo);
-    return {
-      ...pr,
-      accion: "aprobada",
-      motivoAccion: "No crítica y CI en verde — aprobada automáticamente. Falta el merge manual.",
-    };
   });
 }


### PR DESCRIPTION
## Qué pasó

Validando [BRT-143](https://brot74.atlassian.net/browse/BRT-143) con un `workflow_dispatch` real, la corrida falló apenas intentó aprobar la primera PR no crítica:

```
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
```

[Run fallido](https://github.com/gastton/brot74-web/actions/runs/34397454294).

## Causa raíz (dos problemas)

1. **GitHub bloquea a nivel de plataforma** que el `GITHUB_TOKEN` default apruebe PRs — no es un tema de permisos del workflow, es una restricción fija para evitar que un workflow se auto-apruebe sus propios cambios. Hace falta un PAT de una identidad real.
2. **El fallo no atajado tiraba abajo toda la corrida** — una sola PR con problema crasheaba el proceso *antes* de llegar a `actualizarJira()`, dejando sin gestionar los tickets de ese día aunque el resto hubiera salido bien.

## Fix

- [actions.ts](scripts/dependabot-triage/actions.ts): `intentarAprobar()` usa `PR_APPROVE_TOKEN` (PAT dedicado, optativo) en vez de heredar `GH_TOKEN`. Sin el secret, no aprueba pero tampoco rompe.
- El `try/catch` ahora envuelve **todo** el procesamiento por PR (consultar checks + aprobar), no solo el approve — un fallo puntual en cualquier paso reporta esa PR como "no-tocada" con el motivo, y la corrida sigue con el resto (Jira incluido).
- Workflow: pasa el nuevo secret (optativo) al paso de triage.

## Verificación

- **Sin `PR_APPROVE_TOKEN`**: corrido contra las 12 PRs reales de hoy — todas se reportan correctamente sin romper (críticas por su motivo, no críticas con CI verde por falta de token).
- **Resiliencia**: una PR con número inexistente (fuerza que falle la consulta de checks) seguida de una PR real — la primera se reporta con el error, la **segunda se procesa normal**. Confirma que un fallo puntual no frena el resto.

`npx tsc --noEmit` limpio, `npm run lint` sin errores nuevos.

## Lo que falta (acción manual del usuario, mismo patrón que BRT-147/BRT-143)

```
gh secret set PR_APPROVE_TOKEN --repo gastton/brot74-web
```

PAT (classic o fine-grained) con permiso de escritura sobre Pull Requests en este repo. Una vez seteado, validamos con un `workflow_dispatch` real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-143]: https://brot74.atlassian.net/browse/BRT-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ