### PR TITLE
fix(BRT-143): loguear el body real cuando falla el parseo JSON de Jira

### DIFF
--- a/scripts/dependabot-triage/jira.ts
+++ b/scripts/dependabot-triage/jira.ts
@@ -58,12 +58,23 @@ async function jiraFetch<T>(path: string, init?: RequestInit): Promise<T> {
     },
   });
 
+  // Se lee el body una sola vez como texto: evita el error genérico
+  // "Unexpected end of JSON input" que no dice nada — si el parseo falla,
+  // el mensaje de error trae el body real para poder diagnosticarlo.
+  const cuerpoTexto = await res.text().catch(() => "");
+
   if (!res.ok) {
-    const cuerpo = await res.text().catch(() => "");
-    throw new Error(`Jira ${init?.method ?? "GET"} ${path} -> HTTP ${res.status}: ${cuerpo.slice(0, 500)}`);
+    throw new Error(`Jira ${init?.method ?? "GET"} ${path} -> HTTP ${res.status}: ${cuerpoTexto.slice(0, 500)}`);
   }
-  if (res.status === 204) return undefined as T;
-  return (await res.json()) as T;
+  if (!cuerpoTexto) return undefined as T;
+
+  try {
+    return JSON.parse(cuerpoTexto) as T;
+  } catch {
+    throw new Error(
+      `Jira ${init?.method ?? "GET"} ${path} -> HTTP ${res.status} con body no-JSON: ${cuerpoTexto.slice(0, 500)}`,
+    );
+  }
 }
 
 /** Convierte texto plano (párrafos separados por línea en blanco) a ADF. */


### PR DESCRIPTION
## Qué pasó

Validando en vivo con credenciales reales de Jira, la corrida falló con:

```
Falló la gestión de tickets de Jira (se sigue sin romper la corrida): Unexpected end of JSON input
```

Sin ninguna pista de qué llamada falló ni por qué — `await res.json()` no deja rastro del body cuando el parseo falla.

## Fix

`jiraFetch()` ahora lee el body una sola vez como texto y solo intenta `JSON.parse` — si falla, el error incluye el body real (hasta 500 chars) para poder diagnosticar en la próxima corrida. No cambia el comportamiento (sigue no siendo fatal para el resto del pipeline).

`npx tsc --noEmit` limpio, `npm run lint` sin errores nuevos.

## Nota

No pude reproducir esto sin credenciales reales — se merge y se valida con otro `workflow_dispatch`, esta vez con el mensaje de error real a la vista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)