### PR TITLE
feat(BRT-144): notificación a Slack por PR crítica nueva

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -5,9 +5,8 @@ name: Dependabot Triage Agent
 # del repo. Corre en cron todos los días y se puede disparar a mano.
 #
 # Detecta + clasifica (BRT-139/BRT-140), aprueba las no críticas con CI
-# verde (Nivel 1: BRT-142) y gestiona tickets de Jira (BRT-143). Todavía no
-# notifica a Slack (BRT-144) — cuando se implemente, este workflow no
-# necesita cambios: solo va a hacer más el mismo `npm run dependabot:triage`.
+# verde (Nivel 1: BRT-142), gestiona tickets de Jira y avisa por Slack cada
+# crítica nueva (BRT-143/BRT-144).
 
 on:
   schedule:
@@ -63,4 +62,8 @@ jobs:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          # BRT-144: Incoming Webhook del canal de Slack del proyecto.
+          # Optativo: sin este secret, se crean los tickets de Jira pero no
+          # se avisa por Slack.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: npm run dependabot:triage

--- a/scripts/dependabot-triage/index.ts
+++ b/scripts/dependabot-triage/index.ts
@@ -10,8 +10,8 @@ import { classifyDependabotPRs } from "./risk.js";
  *
  * Detecta (BRT-139) + clasifica (BRT-140) + aplica Nivel 1 (BRT-142: aprueba
  * las no críticas con CI en verde, nunca mergea) + gestiona tickets de Jira
- * (BRT-143) y deja un resumen en el job summary de Actions. Todavía NO
- * notifica a Slack (BRT-144) — se suma acá mismo cuando se implemente.
+ * y notifica a Slack por cada crítica nueva (BRT-143/BRT-144) y deja un
+ * resumen en el job summary de Actions.
  */
 
 type PrProcesada = DependabotPrRisk & {
@@ -58,8 +58,8 @@ function resumenMarkdown(procesadas: PrProcesada[], jira: ResultadoJira): string
     "|---|---|---|---|---|---|---|",
     filas,
     "",
-    "_El merge sigue siendo manual en todos los casos. Notificación a Slack todavía no" +
-      " está implementada — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
+    "_El merge sigue siendo manual en todos los casos. Cada crítica nueva también se avisa" +
+      " por Slack — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
     "",
     lineaJira,
   ].join("\n");

--- a/scripts/dependabot-triage/jira.ts
+++ b/scripts/dependabot-triage/jira.ts
@@ -1,6 +1,7 @@
 import type { DependabotPrRisk } from "./github.js";
 import type { AccionResultado } from "./actions.js";
 import type { RiskResult } from "./risk.js";
+import { notificarCritica } from "./slack.js";
 
 /**
  * BRT-143: gestión de tickets Jira del agente de triage.
@@ -10,6 +11,9 @@ import type { RiskResult } from "./risk.js";
  *   crítica sin resolver.
  * - Un ticket dedicado por PR crítica (Bug, label `dependabot-pr-<numero>`)
  *   con el análisis de riesgo. No se autocierra — requiere revisión humana.
+ *   Cuando el ticket es nuevo, dispara además la notificación a Slack
+ *   (BRT-144) — separación de canales: el batch es ruido de rutina, esto
+ *   es señal de atención humana.
  *
  * Habla directo con la Jira REST API v3 (no el MCP de Atlassian: este
  * script corre en un runner de GitHub Actions, no dentro de una sesión de
@@ -145,6 +149,11 @@ async function cerrarComoDone(issueKey: string): Promise<void> {
   });
 }
 
+function urlDelIssue(key: string): string {
+  const baseUrl = (process.env.JIRA_BASE_URL ?? "").replace(/\/$/, "");
+  return `${baseUrl}/browse/${key}`;
+}
+
 function urlDeLaCorrida(): string | undefined {
   const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
   if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return undefined;
@@ -249,6 +258,9 @@ export async function actualizarJira(procesadas: PrProcesada[]): Promise<Resulta
       if (esNuevo) {
         await linkearIssues(batchKey, key);
         criticasNuevas.push(key);
+        // BRT-144: Slack se notifica en el mismo momento en que nace el
+        // ticket dedicado — no en cada corrida que lo vuelve a encontrar.
+        await notificarCritica(pr, key, urlDelIssue(key));
       }
     }
 

--- a/scripts/dependabot-triage/slack.ts
+++ b/scripts/dependabot-triage/slack.ts
@@ -1,0 +1,80 @@
+import type { PrProcesada } from "./jira.js";
+
+/**
+ * BRT-144: notificación a Slack. Se dispara **solo** cuando se crea un
+ * ticket dedicado nuevo por PR crítica (nunca por el ticket batch de
+ * rutina) — separación de canales del diseño de la épica (BRT-137): ruido
+ * operativo de bajo interés vs. señal de alta atención humana.
+ *
+ * Usa un Incoming Webhook (`SLACK_WEBHOOK_URL`). Si falta o falla, no es
+ * fatal — se loguea y el resto de la corrida sigue (mismo criterio que
+ * Dependabot Alerts y Jira).
+ */
+
+function severidadEmoji(severidad?: string): string {
+  switch (severidad) {
+    case "critical":
+      return "🟣";
+    case "high":
+      return "🔴";
+    case "moderate":
+      return "🟠";
+    case "low":
+      return "🟡";
+    default:
+      return "⚪";
+  }
+}
+
+function construirMensaje(pr: PrProcesada, jiraKey: string, jiraUrl: string) {
+  const versiones =
+    pr.versionDesde && pr.versionHasta ? `${pr.versionDesde} → ${pr.versionHasta}` : "sin datos de versión";
+
+  const texto =
+    `${severidadEmoji(pr.severidad)} *PR crítica de Dependabot: \`${pr.paquete}\`* (#${pr.numero})\n` +
+    `Bump: *${pr.bumpType}* (${versiones})\n` +
+    `Severidad: *${pr.severidad ?? "sin CVE asociado"}*\n` +
+    `Motivo: ${pr.motivo}\n` +
+    `<${pr.url}|Ver PR en GitHub> · <${jiraUrl}|${jiraKey} en Jira>`;
+
+  return {
+    text: `PR crítica de Dependabot: ${pr.paquete} (#${pr.numero}) — ${jiraKey}`,
+    blocks: [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: texto },
+      },
+    ],
+  };
+}
+
+/**
+ * Notifica una PR crítica recién detectada (ticket de Jira ya creado).
+ * Nunca tira una excepción — un fallo de Slack no debe frenar el resto de
+ * la corrida.
+ */
+export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl: string): Promise<void> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.warn(`Falta SLACK_WEBHOOK_URL — no se notifica a Slack la PR crítica #${pr.numero}.`);
+    return;
+  }
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(construirMensaje(pr, jiraKey, jiraUrl)),
+    });
+
+    if (!res.ok) {
+      const cuerpo = await res.text().catch(() => "");
+      throw new Error(`Slack webhook -> HTTP ${res.status}: ${cuerpo.slice(0, 300)}`);
+    }
+  } catch (err) {
+    console.warn(
+      `No se pudo notificar a Slack la PR crítica #${pr.numero} (no rompe la corrida):`,
+      (err as Error).message,
+    );
+  }
+}


### PR DESCRIPTION
## Qué

Agrega [scripts/dependabot-triage/slack.ts](scripts/dependabot-triage/slack.ts) — última pieza del flujo de triage ([BRT-137](https://brot74.atlassian.net/browse/BRT-137)):

`notificarCritica()` postea a un Incoming Webhook (`SLACK_WEBHOOK_URL`) con paquete, bump, versión origen/destino, severidad, motivo y links a la PR y al ticket de Jira (Block Kit + fallback de texto plano para notificaciones).

Se dispara desde [jira.ts](scripts/dependabot-triage/jira.ts) en el mismo momento en que nace un ticket dedicado **nuevo** — nunca por el ticket batch de rutina. Separación de canales tal como lo define la épica: batch = ruido operativo de bajo interés, crítica nueva = señal de alta atención humana (Jira + Slack juntos).

Sin `SLACK_WEBHOOK_URL`, o si el POST falla, no es fatal — se loguea y la corrida sigue (mismo criterio que Dependabot Alerts/Jira).

## Verificación

No tengo un webhook real de Slack. Levanté un servidor HTTP local haciendo de webhook falso para inspeccionar el payload real sin depender de credenciales:

- **Sin `SLACK_WEBHOOK_URL`**: warning claro (`Falta SLACK_WEBHOOK_URL — no se notifica...`), no rompe.
- **Con webhook local**: el payload es Block Kit válido — `text` de fallback + un `section` con `mrkdwn`, emoji correcto según severidad (🔴 para `high`), y los dos links en formato Slack (`<url|texto>`) apuntando a la PR real y al ticket de Jira real.
- **Con webhook que responde 500**: no rompe, loguea el error y sigue.

`npx tsc --noEmit` limpio, `npm run lint` sin errores nuevos.

`index.ts` y el workflow ya no dicen "Slack no implementado". Suma `SLACK_WEBHOOK_URL` (optativo) al paso de triage.

## Lo que falta (acción manual del usuario)

Crear un Incoming Webhook en el canal de Slack del proyecto ([api.slack.com/messaging/webhooks](https://api.slack.com/messaging/webhooks)) y setearlo:

```
gh secret set SLACK_WEBHOOK_URL --repo gastton/brot74-web
```

Después validamos con un `workflow_dispatch` real — aunque hoy no hay PRs no-críticas ni nuevas críticas pendientes de crear ticket (ya se crearon todos en la corrida de BRT-143), así que puede no haber nada que disparar Slack hasta que aparezca una PR crítica nueva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-137]: https://brot74.atlassian.net/browse/BRT-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Slack notifications for newly detected critical security vulnerabilities.
  - Notifications include relevant pull request details, severity, and links to the associated Jira ticket.
  - Alerts are sent when a dedicated critical-vulnerability Jira ticket is created.

- **Documentation**
  - Updated triage documentation and job summaries to describe Slack alerting behavior.

- **Reliability**
  - Triage runs continue even when Slack notifications are unavailable or fail to send.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->