### PR TITLE
fix(BRT-144): trim + validación de SLACK_WEBHOOK_URL con diagnóstico seguro

### DIFF
--- a/scripts/dependabot-triage/slack.ts
+++ b/scripts/dependabot-triage/slack.ts
@@ -54,9 +54,25 @@ function construirMensaje(pr: PrProcesada, jiraKey: string, jiraUrl: string) {
  * la corrida.
  */
 export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl: string): Promise<void> {
-  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  // .trim(): `gh secret set` interactivo puede colar un salto de línea o
+  // espacio al final si se pegó desde otro lado — evita un "Failed to
+  // parse URL" por algo tan tonto como eso.
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL?.trim();
   if (!webhookUrl) {
     console.warn(`Falta SLACK_WEBHOOK_URL — no se notifica a Slack la PR crítica #${pr.numero}.`);
+    return;
+  }
+
+  // GitHub Actions enmascara el valor del secret en los logs (sale como
+  // "***"), así que un error de fetch no dice nada útil. La longitud sí
+  // pasa el filtro de enmascarado (no es el secret, es un número) y alcanza
+  // para diagnosticar sin exponer nada: una URL de Incoming Webhook real
+  // ronda los 80-90 caracteres.
+  if (!/^https:\/\//.test(webhookUrl)) {
+    console.warn(
+      `SLACK_WEBHOOK_URL no empieza con "https://" (longitud: ${webhookUrl.length}) — revisá que el secret` +
+        ` tenga solo la URL, sin texto de más. No se notifica la PR crítica #${pr.numero}.`,
+    );
     return;
   }
 


### PR DESCRIPTION
## Qué pasó

Validando en vivo contra el webhook real (`workflow_dispatch`), la corrida falló con:

```
No se pudo notificar a Slack la PR crítica #72 (no rompe la corrida): Failed to parse URL from ***
```

GitHub Actions enmascara el valor del secret en los logs (`***`), así que no hay forma de saber qué está mal en el valor.

## Fix

- `.trim()` antes de usar la URL: `gh secret set` interactivo puede colar un salto de línea o espacio al final.
- Valida que empiece con `https://` antes de intentar el fetch, con un warning que incluye la **longitud** del valor — no es el secret, es un número, así que el filtro de enmascarado de Actions no lo toca — para poder diagnosticar la próxima vez sin exponer nada.

## Verificación

- `trim()` + fetch contra un HTTPS real (`postman-echo.com`) con salto de línea al final al estilo del bug real: funciona limpio, sin warning.
- URL sin `https://` y URL vacía tras `trim()`: devuelven el warning correcto, no rompen la corrida.

`npx tsc --noEmit` limpio, `npm run lint` sin errores nuevos.

## Nota

No pude confirmar la causa exacta del valor real del secret (nunca lo veo, ni siquiera enmascarado). Si esto no lo resuelve, el próximo log va a decir la longitud exacta del valor, lo que ya acota mucho el problema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)