### PR TITLE
fix(BRT-144): chequear el body de la respuesta de Slack, no solo el status

### DIFF
--- a/scripts/dependabot-triage/slack.ts
+++ b/scripts/dependabot-triage/slack.ts
@@ -83,9 +83,14 @@ export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl
       body: JSON.stringify(construirMensaje(pr, jiraKey, jiraUrl)),
     });
 
-    if (!res.ok) {
-      const cuerpo = await res.text().catch(() => "");
-      throw new Error(`Slack webhook -> HTTP ${res.status}: ${cuerpo.slice(0, 300)}`);
+    // Slack responde el webhook con HTTP 200 incluso para varios errores
+    // (ej. "no_service" si el webhook está deshabilitado/borrado,
+    // "channel_not_found", "action_prohibited") — el cuerpo, no el status,
+    // es la única forma de distinguir un envío real de un fallo silencioso.
+    // Éxito real: cuerpo es exactamente el texto "ok".
+    const cuerpo = (await res.text().catch(() => "")).trim();
+    if (!res.ok || cuerpo !== "ok") {
+      throw new Error(`Slack webhook -> HTTP ${res.status}, body: "${cuerpo.slice(0, 300)}"`);
     }
   } catch (err) {
     console.warn(


### PR DESCRIPTION
## Qué pasó

Corrida real (después del fix anterior de la URL): el POST a Slack "salió bien" — sin ningún warning en el log — pero el mensaje nunca llegó al canal.

## Causa

Slack responde el webhook con **HTTP 200 incluso para varios errores** (`no_service` si el webhook está deshabilitado/borrado, `channel_not_found`, etc.) — es un comportamiento conocido de la API de Incoming Webhooks. Mi código solo miraba `res.ok` (status), así que un 200 con body de error se trataba como éxito.

## Fix

`notificarCritica()` ahora exige que el body sea exactamente el texto `"ok"` (lo que Slack devuelve en un envío real) además de un status 2xx. El body del error no es el secret, así que no lo enmascara el filtro de logs de Actions — el próximo fallo va a decir el motivo real en texto plano.

## Verificación

Lógica de chequeo probada en aislado (el gate de `https://` ya se probó en el fix anterior, así que usé un server HTTP local plano para esto):
- body `"ok"` → pasa.
- body `"no_service"` con HTTP 200 → se rechaza.
- HTTP 404 → se rechaza.

`npx tsc --noEmit` limpio, `npm run lint` sin errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)