### PR TITLE
feat(BRT-144): notificación a Slack pasa a resumen de cada corrida

### DIFF
--- a/scripts/dependabot-triage/index.ts
+++ b/scripts/dependabot-triage/index.ts
@@ -3,6 +3,7 @@ import { aplicarNivel1 } from "./actions.js";
 import type { DependabotPrRisk } from "./github.js";
 import { actualizarJira, type ResultadoJira } from "./jira.js";
 import { classifyDependabotPRs } from "./risk.js";
+import { notificarResumenCorrida } from "./slack.js";
 
 /**
  * BRT-141: entrypoint que corre el workflow de GitHub Actions
@@ -10,8 +11,8 @@ import { classifyDependabotPRs } from "./risk.js";
  *
  * Detecta (BRT-139) + clasifica (BRT-140) + aplica Nivel 1 (BRT-142: aprueba
  * las no críticas con CI en verde, nunca mergea) + gestiona tickets de Jira
- * y notifica a Slack por cada crítica nueva (BRT-143/BRT-144) y deja un
- * resumen en el job summary de Actions.
+ * (BRT-143) + manda un resumen a Slack de la corrida completa (BRT-144) y
+ * deja el mismo resumen en el job summary de Actions.
  */
 
 type PrProcesada = DependabotPrRisk & {
@@ -58,8 +59,8 @@ function resumenMarkdown(procesadas: PrProcesada[], jira: ResultadoJira): string
     "|---|---|---|---|---|---|---|",
     filas,
     "",
-    "_El merge sigue siendo manual en todos los casos. Cada crítica nueva también se avisa" +
-      " por Slack — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
+    "_El merge sigue siendo manual en todos los casos. Al final de cada corrida se manda" +
+      " un resumen a Slack — ver [BRT-137](https://brot74.atlassian.net/browse/BRT-137)._",
     "",
     lineaJira,
   ].join("\n");
@@ -79,6 +80,18 @@ async function main(): Promise<void> {
 
   const jira = await actualizarJira(procesadas);
   console.log("Jira:", jira);
+
+  await notificarResumenCorrida({
+    totalEncontradas: procesadas.length,
+    totalResueltasAuto: procesadas.filter((pr) => pr.accion === "aprobada").length,
+    criticasPendientes: jira.criticas.map((c) => ({
+      numero: c.pr.numero,
+      paquete: c.pr.paquete,
+      jiraKey: c.jiraKey,
+      jiraUrl: c.jiraUrl,
+    })),
+    jiraOmitido: jira.omitido,
+  });
 
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {

--- a/scripts/dependabot-triage/jira.ts
+++ b/scripts/dependabot-triage/jira.ts
@@ -1,7 +1,6 @@
 import type { DependabotPrRisk } from "./github.js";
 import type { AccionResultado } from "./actions.js";
 import type { RiskResult } from "./risk.js";
-import { notificarCritica } from "./slack.js";
 
 /**
  * BRT-143: gestión de tickets Jira del agente de triage.
@@ -11,9 +10,10 @@ import { notificarCritica } from "./slack.js";
  *   crítica sin resolver.
  * - Un ticket dedicado por PR crítica (Bug, label `dependabot-pr-<numero>`)
  *   con el análisis de riesgo. No se autocierra — requiere revisión humana.
- *   Cuando el ticket es nuevo, dispara además la notificación a Slack
- *   (BRT-144) — separación de canales: el batch es ruido de rutina, esto
- *   es señal de atención humana.
+ *
+ * No dispara Slack directamente (eso lo arma index.ts con el resultado
+ * completo de la corrida — BRT-144 pasó de notificar por cada ticket
+ * crítico nuevo a mandar un resumen único al final de cada corrida).
  *
  * Habla directo con la Jira REST API v3 (no el MCP de Atlassian: este
  * script corre en un runner de GitHub Actions, no dentro de una sesión de
@@ -31,9 +31,18 @@ const PROJECT_KEY = process.env.JIRA_PROJECT_KEY ?? "BRT";
 
 export type PrProcesada = DependabotPrRisk & RiskResult & AccionResultado;
 
+export interface CriticaConTicket {
+  pr: PrProcesada;
+  jiraKey: string;
+  jiraUrl: string;
+}
+
 export interface ResultadoJira {
   batchKey: string | null;
   criticasNuevas: string[];
+  /** Todas las PRs críticas de la corrida con su ticket (nuevo o ya
+   * existente) — BRT-144 lo usa para listar los pendientes en Slack. */
+  criticas: CriticaConTicket[];
   omitido?: string;
 }
 
@@ -243,34 +252,33 @@ export async function actualizarJira(procesadas: PrProcesada[]): Promise<Resulta
   const faltantes = credencialesFaltantes();
   if (faltantes) {
     console.warn(`${faltantes} — no se gestionan tickets de Jira esta corrida.`);
-    return { batchKey: null, criticasNuevas: [], omitido: faltantes };
+    return { batchKey: null, criticasNuevas: [], criticas: [], omitido: faltantes };
   }
 
   try {
     const fecha = new Date().toISOString().slice(0, 10);
     const batchKey = await findOrCreateBatchIssue(fecha, procesadas);
 
-    const criticas = procesadas.filter((pr) => pr.critica);
+    const criticasDeHoy = procesadas.filter((pr) => pr.critica);
     const criticasNuevas: string[] = [];
+    const criticas: CriticaConTicket[] = [];
 
-    for (const pr of criticas) {
+    for (const pr of criticasDeHoy) {
       const { key, esNuevo } = await findOrCreateCriticalIssue(pr);
+      criticas.push({ pr, jiraKey: key, jiraUrl: urlDelIssue(key) });
       if (esNuevo) {
         await linkearIssues(batchKey, key);
         criticasNuevas.push(key);
-        // BRT-144: Slack se notifica en el mismo momento en que nace el
-        // ticket dedicado — no en cada corrida que lo vuelve a encontrar.
-        await notificarCritica(pr, key, urlDelIssue(key));
       }
     }
 
-    if (criticas.length === 0) {
+    if (criticasDeHoy.length === 0) {
       await cerrarComoDone(batchKey);
     }
 
-    return { batchKey, criticasNuevas };
+    return { batchKey, criticasNuevas, criticas };
   } catch (err) {
     console.warn("Falló la gestión de tickets de Jira (se sigue sin romper la corrida):", (err as Error).message);
-    return { batchKey: null, criticasNuevas: [], omitido: (err as Error).message };
+    return { batchKey: null, criticasNuevas: [], criticas: [], omitido: (err as Error).message };
   }
 }

--- a/scripts/dependabot-triage/slack.ts
+++ b/scripts/dependabot-triage/slack.ts
@@ -1,44 +1,53 @@
-import type { PrProcesada } from "./jira.js";
-
 /**
- * BRT-144: notificación a Slack. Se dispara **solo** cuando se crea un
- * ticket dedicado nuevo por PR crítica (nunca por el ticket batch de
- * rutina) — separación de canales del diseño de la épica (BRT-137): ruido
- * operativo de bajo interés vs. señal de alta atención humana.
+ * BRT-144: notificación a Slack. Se dispara **en cada corrida** del triage
+ * (haya o no PRs críticas) con un resumen: cuántas PRs se encontraron,
+ * cuántas se resolvieron solas (Nivel 1) y cuáles críticas quedan
+ * pendientes, cada una con link directo a su ticket de Jira.
  *
  * Usa un Incoming Webhook (`SLACK_WEBHOOK_URL`). Si falta o falla, no es
  * fatal — se loguea y el resto de la corrida sigue (mismo criterio que
- * Dependabot Alerts y Jira).
+ * Dependabot Alerts y Jira). No vuelve a consultar Jira/GitHub por su
+ * cuenta: arma el mensaje solo con lo que ya generó la corrida.
  */
 
-function severidadEmoji(severidad?: string): string {
-  switch (severidad) {
-    case "critical":
-      return "🟣";
-    case "high":
-      return "🔴";
-    case "moderate":
-      return "🟠";
-    case "low":
-      return "🟡";
-    default:
-      return "⚪";
-  }
+export interface CriticaPendiente {
+  numero: number;
+  paquete: string;
+  jiraKey: string;
+  jiraUrl: string;
 }
 
-function construirMensaje(pr: PrProcesada, jiraKey: string, jiraUrl: string) {
-  const versiones =
-    pr.versionDesde && pr.versionHasta ? `${pr.versionDesde} → ${pr.versionHasta}` : "sin datos de versión";
+export interface ResumenCorrida {
+  totalEncontradas: number;
+  totalResueltasAuto: number;
+  criticasPendientes: CriticaPendiente[];
+  /** Motivo por el que Jira no pudo confirmar el estado de las críticas
+   * esta corrida (credenciales ausentes, Jira caído) — si está presente,
+   * `criticasPendientes` puede no reflejar la realidad. */
+  jiraOmitido?: string;
+}
+
+// Exportada para poder verificar el formato del mensaje sin pasar por la
+// red (el resto de la función hace fetch a un webhook real).
+export function construirMensaje(resumen: ResumenCorrida) {
+  const { totalEncontradas, totalResueltasAuto, criticasPendientes, jiraOmitido } = resumen;
+
+  const seccionCriticas = jiraOmitido
+    ? `⚠️ No se pudo confirmar el estado de las críticas en Jira esta corrida (${jiraOmitido}).`
+    : criticasPendientes.length === 0
+      ? "✅ Ninguna crítica pendiente."
+      : criticasPendientes
+          .map((c) => `⚠️ <${c.jiraUrl}|${c.jiraKey}> — \`${c.paquete}\` (#${c.numero})`)
+          .join("\n");
 
   const texto =
-    `${severidadEmoji(pr.severidad)} *PR crítica de Dependabot: \`${pr.paquete}\`* (#${pr.numero})\n` +
-    `Bump: *${pr.bumpType}* (${versiones})\n` +
-    `Severidad: *${pr.severidad ?? "sin CVE asociado"}*\n` +
-    `Motivo: ${pr.motivo}\n` +
-    `<${pr.url}|Ver PR en GitHub> · <${jiraUrl}|${jiraKey} en Jira>`;
+    `🤖 *Triage de Dependabot*\n` +
+    `PRs encontradas: *${totalEncontradas}*\n` +
+    `Resueltas automáticamente: *${totalResueltasAuto}*\n\n` +
+    seccionCriticas;
 
   return {
-    text: `PR crítica de Dependabot: ${pr.paquete} (#${pr.numero}) — ${jiraKey}`,
+    text: `Triage de Dependabot: ${totalEncontradas} PR(s), ${criticasPendientes.length} crítica(s) pendiente(s)`,
     blocks: [
       {
         type: "section",
@@ -49,17 +58,16 @@ function construirMensaje(pr: PrProcesada, jiraKey: string, jiraUrl: string) {
 }
 
 /**
- * Notifica una PR crítica recién detectada (ticket de Jira ya creado).
- * Nunca tira una excepción — un fallo de Slack no debe frenar el resto de
- * la corrida.
+ * Notifica el resumen de la corrida completa. Nunca tira una excepción —
+ * un fallo de Slack no debe frenar el resto de la corrida.
  */
-export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl: string): Promise<void> {
+export async function notificarResumenCorrida(resumen: ResumenCorrida): Promise<void> {
   // .trim(): `gh secret set` interactivo puede colar un salto de línea o
   // espacio al final si se pegó desde otro lado — evita un "Failed to
   // parse URL" por algo tan tonto como eso.
   const webhookUrl = process.env.SLACK_WEBHOOK_URL?.trim();
   if (!webhookUrl) {
-    console.warn(`Falta SLACK_WEBHOOK_URL — no se notifica a Slack la PR crítica #${pr.numero}.`);
+    console.warn("Falta SLACK_WEBHOOK_URL — no se notifica el resumen de la corrida a Slack.");
     return;
   }
 
@@ -71,7 +79,7 @@ export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl
   if (!/^https:\/\//.test(webhookUrl)) {
     console.warn(
       `SLACK_WEBHOOK_URL no empieza con "https://" (longitud: ${webhookUrl.length}) — revisá que el secret` +
-        ` tenga solo la URL, sin texto de más. No se notifica la PR crítica #${pr.numero}.`,
+        ` tenga solo la URL, sin texto de más. No se notifica el resumen.`,
     );
     return;
   }
@@ -80,7 +88,7 @@ export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl
     const res = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(construirMensaje(pr, jiraKey, jiraUrl)),
+      body: JSON.stringify(construirMensaje(resumen)),
     });
 
     // Slack responde el webhook con HTTP 200 incluso para varios errores
@@ -93,9 +101,6 @@ export async function notificarCritica(pr: PrProcesada, jiraKey: string, jiraUrl
       throw new Error(`Slack webhook -> HTTP ${res.status}, body: "${cuerpo.slice(0, 300)}"`);
     }
   } catch (err) {
-    console.warn(
-      `No se pudo notificar a Slack la PR crítica #${pr.numero} (no rompe la corrida):`,
-      (err as Error).message,
-    );
+    console.warn("No se pudo notificar el resumen a Slack (no rompe la corrida):", (err as Error).message);
   }
 }


### PR DESCRIPTION
## Qué

[BRT-144](https://brot74.atlassian.net/browse/BRT-144) cambió de alcance mientras se implementaba la versión anterior (ya mergeada y validada en vivo, PRs [#124](https://github.com/gastton/brot74-web/pull/124)/[#125](https://github.com/gastton/brot74-web/pull/125)/[#126](https://github.com/gastton/brot74-web/pull/126)): en vez de notificar solo cuando nace un ticket crítico dedicado, ahora manda un resumen al final de **cada corrida** del triage, haya o no críticas.

Formato del mensaje:
- Total de PRs de Dependabot encontradas.
- Total resueltas automáticamente (aprobadas por Nivel 1).
- Si hay críticas pendientes: listado con ⚠️ y link directo a cada ticket de Jira.
- Si no hay ninguna: `✅ Ninguna crítica pendiente.` explícito, no un listado vacío ambiguo.
- Si Jira no pudo confirmar el estado esta corrida (credenciales ausentes, falla): se avisa explícitamente en vez de mostrar 0 críticas como si todo estuviera resuelto.

## Cambios de arquitectura

- [jira.ts](scripts/dependabot-triage/jira.ts) ya no dispara Slack directamente — devuelve `criticas` (todas las PRs críticas del día con su ticket, nuevo o reusado) para que `index.ts` arme el resumen completo al final del pipeline.
- [slack.ts](scripts/dependabot-triage/slack.ts) queda con una sola función, `notificarResumenCorrida()`.
- Mismo manejo de errores que la versión anterior, ya probado en producción real: `trim()` de la URL, validación de `https://`, chequeo del body real (Slack responde 200 incluso en errores como `no_service`).

## Verificación

Exporté `construirMensaje()` para probar el formato sin red (los 3 casos: con críticas, sin críticas, Jira omitido) — todos correctos. El resto del pipeline HTTP (trim, validación, chequeo de body) es el mismo código ya validado en producción en los PRs anteriores.

`npx tsc --noEmit` limpio, `npm run lint` sin errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BRT-144]: https://brot74.atlassian.net/browse/BRT-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ